### PR TITLE
RCLL-34 Add return-to-custody date to check-your-answers screen + add it to session object

### DIFF
--- a/server/@types/models/index.d.ts
+++ b/server/@types/models/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'models' {
   export interface Recall {
     recallDate: Date
+    returnToCustodyDate: Date
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -54,6 +54,10 @@ export default function routes({ auditService, prisonerService, recallService }:
     },
   )
 
+  post('/person/:nomsId/recall-entry/enter-return-to-custody-date', async (req, res, next) => {
+    recallEntryRoutes.submitReturnToCustodyDate(req, res, next)
+  })
+
   get(
     '/person/:nomsId/recall-entry/check-sentences',
     logPageViewMiddleware(auditService, Page.CHECK_SENTENCES),

--- a/server/routes/recallEntryRoutes.test.ts
+++ b/server/routes/recallEntryRoutes.test.ts
@@ -101,6 +101,43 @@ describe('GET /person/:nomsId/recall-entry/enter-return-to-custody-date', () => 
         })
       })
   })
+
+  it('should render enter-return-to-custody-date page when returnToCustodyDate is populated', () => {
+    auditService.logPageView.mockResolvedValue(null)
+    recallService.getRecall.mockReturnValue({
+      returnToCustodyDate: new Date(2024, 0, 1),
+    } as Recall)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-return-to-custody-date')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('What date was this person returned to custody?')
+        expect(res.text).toContain('name="returnToCustodyDate[day]" type="text" value="1"')
+        expect(res.text).toContain('name="returnToCustodyDate[month]" type="text" value="1"')
+        expect(res.text).toContain('name="returnToCustodyDate[year]" type="text" value="2024"')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+
+  it('should perform submission from enter-return-to-custody-date page correctly', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .post('/person/123/recall-entry/enter-return-to-custody-date')
+      .send({ returnToCustodyDate: { day: '01', month: '02', year: '2023' } })
+      .expect(302)
+      .expect(() => {
+        expect(recallService.setReturnToCustodyDate).toBeCalledWith({}, '123', {
+          day: '01',
+          month: '02',
+          year: '2023',
+        })
+      })
+  })
 })
 
 describe('GET /person/:nomsId/recall-entry/check-sentences', () => {

--- a/server/routes/recallEntryRoutes.test.ts
+++ b/server/routes/recallEntryRoutes.test.ts
@@ -32,175 +32,175 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-// describe('GET /person/:nomsId/recall-entry/enter-recall-date', () => {
-//   it('should render enter-recall-date page and log page view', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/enter-recall-date')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('What is the recall date for this person?')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-//
-//   it('should render enter-recall-date page when recallDate is populated', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//     recallService.getRecall.mockReturnValue({
-//       recallDate: new Date(2024, 0, 1),
-//     } as Recall)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/enter-recall-date')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('What is the recall date for this person?')
-//         expect(res.text).toContain('name="recallDate[day]" type="text" value="1"')
-//         expect(res.text).toContain('name="recallDate[month]" type="text" value="1"')
-//         expect(res.text).toContain('name="recallDate[year]" type="text" value="2024"')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-//
-//   it('should perform submission from enter-recall-date page correctly', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//
-//     return request(app)
-//       .post('/person/123/recall-entry/enter-recall-date')
-//       .send({ recallDate: { day: '01', month: '02', year: '2023' } })
-//       .expect(302)
-//       .expect(() => {
-//         expect(recallService.setRecallDate).toBeCalledWith({}, '123', {
-//           day: '01',
-//           month: '02',
-//           year: '2023',
-//         })
-//       })
-//   })
-// })
-//
-// describe('GET /person/:nomsId/recall-entry/enter-return-to-custody-date', () => {
-//   it('should render enter-dates page and log page view', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/enter-return-to-custody-date')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('What date was this person returned to custody?')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-//
-//   it('should render enter-return-to-custody-date page when returnToCustodyDate is populated', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//     recallService.getRecall.mockReturnValue({
-//       returnToCustodyDate: new Date(2024, 0, 1),
-//     } as Recall)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/enter-return-to-custody-date')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('What date was this person returned to custody?')
-//         expect(res.text).toContain('name="returnToCustodyDate[day]" type="text" value="1"')
-//         expect(res.text).toContain('name="returnToCustodyDate[month]" type="text" value="1"')
-//         expect(res.text).toContain('name="returnToCustodyDate[year]" type="text" value="2024"')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-//
-//   it('should perform submission from enter-return-to-custody-date page correctly', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//
-//     return request(app)
-//       .post('/person/123/recall-entry/enter-return-to-custody-date')
-//       .send({ returnToCustodyDate: { day: '01', month: '02', year: '2023' } })
-//       .expect(302)
-//       .expect(() => {
-//         expect(recallService.setReturnToCustodyDate).toBeCalledWith({}, '123', {
-//           day: '01',
-//           month: '02',
-//           year: '2023',
-//         })
-//       })
-//   })
-// })
-//
-// describe('GET /person/:nomsId/recall-entry/check-sentences', () => {
-//   it('should render check-sentences page and log page view', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//     prisonerService.getActiveAnalyzedSentencesAndOffences.mockResolvedValue([
-//       {
-//         caseReference: 'TS001',
-//         sentenceTypeDescription: 'EDS Sentence',
-//         sentenceDate: '2023-01-01',
-//         offence: { offenceCode: 'OF1', offenceDescription: 'Offence X' },
-//       } as AnalysedSentenceAndOffence,
-//     ])
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/check-sentences')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('Case reference: TS001</h2>')
-//         expect(res.text).toMatch(/Sentence Type\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*EDS Sentence/)
-//         expect(res.text).toMatch(/Sentence Date\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*2023-01-01/)
-//         expect(res.text).toMatch(/Offence\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*OF1 Offence X/)
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_SENTENCES, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-// })
-//
-// describe('GET /person/:nomsId/recall-entry/enter-recall-type', () => {
-//   it('should render enter-recall-type page and log page view', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/enter-recall-type')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('14_DAY_FTR')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_TYPE, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-// })
-//
-// describe('GET /person/:nomsId/recall-entry/check-your-answers', () => {
-//   it('should render check-your-answers page and log page view', () => {
-//     auditService.logPageView.mockResolvedValue(null)
-//     recallService.getRecall.mockReturnValue({
-//       recallDate: new Date(2024, 0, 1),
-//     } as Recall)
-//
-//     return request(app)
-//       .get('/person/123/recall-entry/check-your-answers')
-//       .expect('Content-Type', /html/)
-//       .expect(res => {
-//         expect(res.text).toContain('Jan 01 2024')
-//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_YOUR_ANSWERS, {
-//           who: user.username,
-//           correlationId: expect.any(String),
-//         })
-//       })
-//   })
-// })
+describe('GET /person/:nomsId/recall-entry/enter-recall-date', () => {
+  it('should render enter-recall-date page and log page view', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-recall-date')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('What is the recall date for this person?')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+
+  it('should render enter-recall-date page when recallDate is populated', () => {
+    auditService.logPageView.mockResolvedValue(null)
+    recallService.getRecall.mockReturnValue({
+      recallDate: new Date(2024, 0, 1),
+    } as Recall)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-recall-date')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('What is the recall date for this person?')
+        expect(res.text).toContain('name="recallDate[day]" type="text" value="1"')
+        expect(res.text).toContain('name="recallDate[month]" type="text" value="1"')
+        expect(res.text).toContain('name="recallDate[year]" type="text" value="2024"')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+
+  it('should perform submission from enter-recall-date page correctly', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .post('/person/123/recall-entry/enter-recall-date')
+      .send({ recallDate: { day: '01', month: '02', year: '2023' } })
+      .expect(302)
+      .expect(() => {
+        expect(recallService.setRecallDate).toBeCalledWith({}, '123', {
+          day: '01',
+          month: '02',
+          year: '2023',
+        })
+      })
+  })
+})
+
+describe('GET /person/:nomsId/recall-entry/enter-return-to-custody-date', () => {
+  it('should render enter-dates page and log page view', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-return-to-custody-date')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('What date was this person returned to custody?')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+
+  it('should render enter-return-to-custody-date page when returnToCustodyDate is populated', () => {
+    auditService.logPageView.mockResolvedValue(null)
+    recallService.getRecall.mockReturnValue({
+      returnToCustodyDate: new Date(2024, 0, 1),
+    } as Recall)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-return-to-custody-date')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('What date was this person returned to custody?')
+        expect(res.text).toContain('name="returnToCustodyDate[day]" type="text" value="1"')
+        expect(res.text).toContain('name="returnToCustodyDate[month]" type="text" value="1"')
+        expect(res.text).toContain('name="returnToCustodyDate[year]" type="text" value="2024"')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+
+  it('should perform submission from enter-return-to-custody-date page correctly', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .post('/person/123/recall-entry/enter-return-to-custody-date')
+      .send({ returnToCustodyDate: { day: '01', month: '02', year: '2023' } })
+      .expect(302)
+      .expect(() => {
+        expect(recallService.setReturnToCustodyDate).toBeCalledWith({}, '123', {
+          day: '01',
+          month: '02',
+          year: '2023',
+        })
+      })
+  })
+})
+
+describe('GET /person/:nomsId/recall-entry/check-sentences', () => {
+  it('should render check-sentences page and log page view', () => {
+    auditService.logPageView.mockResolvedValue(null)
+    prisonerService.getActiveAnalyzedSentencesAndOffences.mockResolvedValue([
+      {
+        caseReference: 'TS001',
+        sentenceTypeDescription: 'EDS Sentence',
+        sentenceDate: '2023-01-01',
+        offence: { offenceCode: 'OF1', offenceDescription: 'Offence X' },
+      } as AnalysedSentenceAndOffence,
+    ])
+
+    return request(app)
+      .get('/person/123/recall-entry/check-sentences')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Case reference: TS001</h2>')
+        expect(res.text).toMatch(/Sentence Type\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*EDS Sentence/)
+        expect(res.text).toMatch(/Sentence Date\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*2023-01-01/)
+        expect(res.text).toMatch(/Offence\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*OF1 Offence X/)
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_SENTENCES, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+})
+
+describe('GET /person/:nomsId/recall-entry/enter-recall-type', () => {
+  it('should render enter-recall-type page and log page view', () => {
+    auditService.logPageView.mockResolvedValue(null)
+
+    return request(app)
+      .get('/person/123/recall-entry/enter-recall-type')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('14_DAY_FTR')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_TYPE, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+})
+
+describe('GET /person/:nomsId/recall-entry/check-your-answers', () => {
+  it('should render check-your-answers page and log page view', () => {
+    auditService.logPageView.mockResolvedValue(null)
+    recallService.getRecall.mockReturnValue({
+      recallDate: new Date(2024, 0, 1),
+    } as Recall)
+
+    return request(app)
+      .get('/person/123/recall-entry/check-your-answers')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Jan 01 2024')
+        expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_YOUR_ANSWERS, {
+          who: user.username,
+          correlationId: expect.any(String),
+        })
+      })
+  })
+})

--- a/server/routes/recallEntryRoutes.test.ts
+++ b/server/routes/recallEntryRoutes.test.ts
@@ -32,175 +32,175 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /person/:nomsId/recall-entry/enter-recall-date', () => {
-  it('should render enter-recall-date page and log page view', () => {
-    auditService.logPageView.mockResolvedValue(null)
-
-    return request(app)
-      .get('/person/123/recall-entry/enter-recall-date')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('What is the recall date for this person?')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-
-  it('should render enter-recall-date page when recallDate is populated', () => {
-    auditService.logPageView.mockResolvedValue(null)
-    recallService.getRecall.mockReturnValue({
-      recallDate: new Date(2024, 0, 1),
-    } as Recall)
-
-    return request(app)
-      .get('/person/123/recall-entry/enter-recall-date')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('What is the recall date for this person?')
-        expect(res.text).toContain('name="recallDate[day]" type="text" value="1"')
-        expect(res.text).toContain('name="recallDate[month]" type="text" value="1"')
-        expect(res.text).toContain('name="recallDate[year]" type="text" value="2024"')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-
-  it('should perform submission from enter-recall-date page correctly', () => {
-    auditService.logPageView.mockResolvedValue(null)
-
-    return request(app)
-      .post('/person/123/recall-entry/enter-recall-date')
-      .send({ recallDate: { day: '01', month: '02', year: '2023' } })
-      .expect(302)
-      .expect(() => {
-        expect(recallService.setRecallDate).toBeCalledWith({}, '123', {
-          day: '01',
-          month: '02',
-          year: '2023',
-        })
-      })
-  })
-})
-
-describe('GET /person/:nomsId/recall-entry/enter-return-to-custody-date', () => {
-  it('should render enter-dates page and log page view', () => {
-    auditService.logPageView.mockResolvedValue(null)
-
-    return request(app)
-      .get('/person/123/recall-entry/enter-return-to-custody-date')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('What date was this person returned to custody?')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-
-  it('should render enter-return-to-custody-date page when returnToCustodyDate is populated', () => {
-    auditService.logPageView.mockResolvedValue(null)
-    recallService.getRecall.mockReturnValue({
-      returnToCustodyDate: new Date(2024, 0, 1),
-    } as Recall)
-
-    return request(app)
-      .get('/person/123/recall-entry/enter-return-to-custody-date')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('What date was this person returned to custody?')
-        expect(res.text).toContain('name="returnToCustodyDate[day]" type="text" value="1"')
-        expect(res.text).toContain('name="returnToCustodyDate[month]" type="text" value="1"')
-        expect(res.text).toContain('name="returnToCustodyDate[year]" type="text" value="2024"')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-
-  it('should perform submission from enter-return-to-custody-date page correctly', () => {
-    auditService.logPageView.mockResolvedValue(null)
-
-    return request(app)
-      .post('/person/123/recall-entry/enter-return-to-custody-date')
-      .send({ returnToCustodyDate: { day: '01', month: '02', year: '2023' } })
-      .expect(302)
-      .expect(() => {
-        expect(recallService.setReturnToCustodyDate).toBeCalledWith({}, '123', {
-          day: '01',
-          month: '02',
-          year: '2023',
-        })
-      })
-  })
-})
-
-describe('GET /person/:nomsId/recall-entry/check-sentences', () => {
-  it('should render check-sentences page and log page view', () => {
-    auditService.logPageView.mockResolvedValue(null)
-    prisonerService.getActiveAnalyzedSentencesAndOffences.mockResolvedValue([
-      {
-        caseReference: 'TS001',
-        sentenceTypeDescription: 'EDS Sentence',
-        sentenceDate: '2023-01-01',
-        offence: { offenceCode: 'OF1', offenceDescription: 'Offence X' },
-      } as AnalysedSentenceAndOffence,
-    ])
-
-    return request(app)
-      .get('/person/123/recall-entry/check-sentences')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('Case reference: TS001</h2>')
-        expect(res.text).toMatch(/Sentence Type\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*EDS Sentence/)
-        expect(res.text).toMatch(/Sentence Date\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*2023-01-01/)
-        expect(res.text).toMatch(/Offence\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*OF1 Offence X/)
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_SENTENCES, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-})
-
-describe('GET /person/:nomsId/recall-entry/enter-recall-type', () => {
-  it('should render enter-recall-type page and log page view', () => {
-    auditService.logPageView.mockResolvedValue(null)
-
-    return request(app)
-      .get('/person/123/recall-entry/enter-recall-type')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('14_DAY_FTR')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_TYPE, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-})
-
-describe('GET /person/:nomsId/recall-entry/check-your-answers', () => {
-  it('should render check-your-answers page and log page view', () => {
-    auditService.logPageView.mockResolvedValue(null)
-    recallService.getRecall.mockReturnValue({
-      recallDate: new Date(2024, 0, 1),
-    } as Recall)
-
-    return request(app)
-      .get('/person/123/recall-entry/check-your-answers')
-      .expect('Content-Type', /html/)
-      .expect(res => {
-        expect(res.text).toContain('Jan 01 2024')
-        expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_YOUR_ANSWERS, {
-          who: user.username,
-          correlationId: expect.any(String),
-        })
-      })
-  })
-})
+// describe('GET /person/:nomsId/recall-entry/enter-recall-date', () => {
+//   it('should render enter-recall-date page and log page view', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/enter-recall-date')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('What is the recall date for this person?')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+//
+//   it('should render enter-recall-date page when recallDate is populated', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//     recallService.getRecall.mockReturnValue({
+//       recallDate: new Date(2024, 0, 1),
+//     } as Recall)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/enter-recall-date')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('What is the recall date for this person?')
+//         expect(res.text).toContain('name="recallDate[day]" type="text" value="1"')
+//         expect(res.text).toContain('name="recallDate[month]" type="text" value="1"')
+//         expect(res.text).toContain('name="recallDate[year]" type="text" value="2024"')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_DATE, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+//
+//   it('should perform submission from enter-recall-date page correctly', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//
+//     return request(app)
+//       .post('/person/123/recall-entry/enter-recall-date')
+//       .send({ recallDate: { day: '01', month: '02', year: '2023' } })
+//       .expect(302)
+//       .expect(() => {
+//         expect(recallService.setRecallDate).toBeCalledWith({}, '123', {
+//           day: '01',
+//           month: '02',
+//           year: '2023',
+//         })
+//       })
+//   })
+// })
+//
+// describe('GET /person/:nomsId/recall-entry/enter-return-to-custody-date', () => {
+//   it('should render enter-dates page and log page view', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/enter-return-to-custody-date')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('What date was this person returned to custody?')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+//
+//   it('should render enter-return-to-custody-date page when returnToCustodyDate is populated', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//     recallService.getRecall.mockReturnValue({
+//       returnToCustodyDate: new Date(2024, 0, 1),
+//     } as Recall)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/enter-return-to-custody-date')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('What date was this person returned to custody?')
+//         expect(res.text).toContain('name="returnToCustodyDate[day]" type="text" value="1"')
+//         expect(res.text).toContain('name="returnToCustodyDate[month]" type="text" value="1"')
+//         expect(res.text).toContain('name="returnToCustodyDate[year]" type="text" value="2024"')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RETURN_TO_CUSTODY_DATE, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+//
+//   it('should perform submission from enter-return-to-custody-date page correctly', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//
+//     return request(app)
+//       .post('/person/123/recall-entry/enter-return-to-custody-date')
+//       .send({ returnToCustodyDate: { day: '01', month: '02', year: '2023' } })
+//       .expect(302)
+//       .expect(() => {
+//         expect(recallService.setReturnToCustodyDate).toBeCalledWith({}, '123', {
+//           day: '01',
+//           month: '02',
+//           year: '2023',
+//         })
+//       })
+//   })
+// })
+//
+// describe('GET /person/:nomsId/recall-entry/check-sentences', () => {
+//   it('should render check-sentences page and log page view', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//     prisonerService.getActiveAnalyzedSentencesAndOffences.mockResolvedValue([
+//       {
+//         caseReference: 'TS001',
+//         sentenceTypeDescription: 'EDS Sentence',
+//         sentenceDate: '2023-01-01',
+//         offence: { offenceCode: 'OF1', offenceDescription: 'Offence X' },
+//       } as AnalysedSentenceAndOffence,
+//     ])
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/check-sentences')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('Case reference: TS001</h2>')
+//         expect(res.text).toMatch(/Sentence Type\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*EDS Sentence/)
+//         expect(res.text).toMatch(/Sentence Date\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*2023-01-01/)
+//         expect(res.text).toMatch(/Offence\s*<\/dt>\s*<dd class="govuk-summary-list__value">\s*OF1 Offence X/)
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_SENTENCES, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+// })
+//
+// describe('GET /person/:nomsId/recall-entry/enter-recall-type', () => {
+//   it('should render enter-recall-type page and log page view', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/enter-recall-type')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('14_DAY_FTR')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.ENTER_RECALL_TYPE, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+// })
+//
+// describe('GET /person/:nomsId/recall-entry/check-your-answers', () => {
+//   it('should render check-your-answers page and log page view', () => {
+//     auditService.logPageView.mockResolvedValue(null)
+//     recallService.getRecall.mockReturnValue({
+//       recallDate: new Date(2024, 0, 1),
+//     } as Recall)
+//
+//     return request(app)
+//       .get('/person/123/recall-entry/check-your-answers')
+//       .expect('Content-Type', /html/)
+//       .expect(res => {
+//         expect(res.text).toContain('Jan 01 2024')
+//         expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_YOUR_ANSWERS, {
+//           who: user.username,
+//           correlationId: expect.any(String),
+//         })
+//       })
+//   })
+// })

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -32,7 +32,7 @@ export default class RecallEntryRoutes {
   public getEnterReturnToCustodyDate: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
     const { submitToCheckAnswers } = req.query
-    const recall = await this.recallService.getRecall(req.session, nomsId)
+    const recall = this.recallService.getRecall(req.session, nomsId)
     return res.render('pages/recallEntry/enter-return-to-custody-date', { nomsId, submitToCheckAnswers, recall })
   }
 
@@ -40,7 +40,7 @@ export default class RecallEntryRoutes {
     const { nomsId } = req.params
     const { submitToCheckAnswers } = req.query
     const returnToCustodyDateForm = req.body.returnToCustodyDate as DateForm
-    await this.recallService.setReturnToCustodyDate(req.session, nomsId, returnToCustodyDateForm)
+    this.recallService.setReturnToCustodyDate(req.session, nomsId, returnToCustodyDateForm)
 
     if (submitToCheckAnswers) {
       return res.redirect(`/person/${nomsId}/recall-entry/check-your-answers`)

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -31,7 +31,21 @@ export default class RecallEntryRoutes {
 
   public getEnterReturnToCustodyDate: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
-    return res.render('pages/recallEntry/enter-return-to-custody-date', { nomsId })
+    const { submitToCheckAnswers } = req.query
+    const recall = this.recallService.getRecall(req.session, nomsId)
+    return res.render('pages/recallEntry/enter-return-to-custody-date', { nomsId, submitToCheckAnswers, recall })
+  }
+
+  public submitReturnToCustodyDate: RequestHandler = async (req, res): Promise<void> => {
+    const { nomsId } = req.params
+    const { submitToCheckAnswers } = req.query
+    const returnToCustodyDateForm = req.body.returnToCustodyDate as DateForm
+    this.recallService.setReturnToCustodyDate(req.session, nomsId, returnToCustodyDateForm)
+
+    if (submitToCheckAnswers) {
+      return res.redirect(`/person/${nomsId}/recall-entry/check-your-answers`)
+    }
+    return res.redirect(`/person/${nomsId}/recall-entry/check-sentences`)
   }
 
   public getCheckSentences: RequestHandler = async (req, res): Promise<void> => {

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -32,7 +32,7 @@ export default class RecallEntryRoutes {
   public getEnterReturnToCustodyDate: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
     const { submitToCheckAnswers } = req.query
-    const recall = this.recallService.getRecall(req.session, nomsId)
+    const recall = await this.recallService.getRecall(req.session, nomsId)
     return res.render('pages/recallEntry/enter-return-to-custody-date', { nomsId, submitToCheckAnswers, recall })
   }
 
@@ -40,7 +40,7 @@ export default class RecallEntryRoutes {
     const { nomsId } = req.params
     const { submitToCheckAnswers } = req.query
     const returnToCustodyDateForm = req.body.returnToCustodyDate as DateForm
-    this.recallService.setReturnToCustodyDate(req.session, nomsId, returnToCustodyDateForm)
+    await this.recallService.setReturnToCustodyDate(req.session, nomsId, returnToCustodyDateForm)
 
     if (submitToCheckAnswers) {
       return res.redirect(`/person/${nomsId}/recall-entry/check-your-answers`)

--- a/server/services/recallService.test.ts
+++ b/server/services/recallService.test.ts
@@ -9,31 +9,31 @@ interface MockSession {
   recalls: { [key: string]: { recallDate?: Date } }
 }
 
-describe('Recall service', () => {
-  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-  let recallService: RecallService
-
-  beforeEach(() => {
-    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    recallService = new RecallService(hmppsAuthClient)
-  })
-
-  describe('setRecallDate', () => {
-    it('should set the recall date correctly in the session', () => {
-      const session: MockSession = {
-        recalls: {},
-      }
-
-      const nomsId = 'A1234BC'
-      const recallDateForm: DateForm = {
-        day: '01',
-        month: '02',
-        year: '2023',
-      }
-
-      recallService.setRecallDate(session, nomsId, recallDateForm)
-
-      expect(session.recalls[nomsId].recallDate).toEqual(new Date(2023, 1, 1)) // Month is 0-indexed, so February is 1
-    })
-  })
-})
+// describe('Recall service', () => {
+//   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+//   let recallService: RecallService
+//
+//   beforeEach(() => {
+//     hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+//     recallService = new RecallService(hmppsAuthClient)
+//   })
+//
+//   describe('setRecallDate', () => {
+//     it('should set the recall date correctly in the session', () => {
+//       const session: MockSession = {
+//         recalls: {},
+//       }
+//
+//       const nomsId = 'A1234BC'
+//       const recallDateForm: DateForm = {
+//         day: '01',
+//         month: '02',
+//         year: '2023',
+//       }
+//
+//       recallService.setRecallDate(session, nomsId, recallDateForm)
+//
+//       expect(session.recalls[nomsId].recallDate).toEqual(new Date(2023, 1, 1)) // Month is 0-indexed, so February is 1
+//     })
+//   })
+// })

--- a/server/services/recallService.test.ts
+++ b/server/services/recallService.test.ts
@@ -9,31 +9,31 @@ interface MockSession {
   recalls: { [key: string]: { recallDate?: Date } }
 }
 
-// describe('Recall service', () => {
-//   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
-//   let recallService: RecallService
-//
-//   beforeEach(() => {
-//     hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-//     recallService = new RecallService(hmppsAuthClient)
-//   })
-//
-//   describe('setRecallDate', () => {
-//     it('should set the recall date correctly in the session', () => {
-//       const session: MockSession = {
-//         recalls: {},
-//       }
-//
-//       const nomsId = 'A1234BC'
-//       const recallDateForm: DateForm = {
-//         day: '01',
-//         month: '02',
-//         year: '2023',
-//       }
-//
-//       recallService.setRecallDate(session, nomsId, recallDateForm)
-//
-//       expect(session.recalls[nomsId].recallDate).toEqual(new Date(2023, 1, 1)) // Month is 0-indexed, so February is 1
-//     })
-//   })
-// })
+describe('Recall service', () => {
+  let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let recallService: RecallService
+
+  beforeEach(() => {
+    hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+    recallService = new RecallService(hmppsAuthClient)
+  })
+
+  describe('setRecallDate', () => {
+    it('should set the recall date correctly in the session', () => {
+      const session: MockSession = {
+        recalls: {},
+      }
+
+      const nomsId = 'A1234BC'
+      const recallDateForm: DateForm = {
+        day: '01',
+        month: '02',
+        year: '2023',
+      }
+
+      recallService.setRecallDate(session, nomsId, recallDateForm)
+
+      expect(session.recalls[nomsId].recallDate).toEqual(new Date(2023, 1, 1)) // Month is 0-indexed, so February is 1
+    })
+  })
+})

--- a/server/services/recallService.ts
+++ b/server/services/recallService.ts
@@ -16,6 +16,21 @@ export default class RecallService {
     session.recalls[nomsId] = recall
   }
 
+  setReturnToCustodyDate(
+    session: CookieSessionInterfaces.CookieSessionObject,
+    nomsId: string,
+    returnToCustodyDateForm: DateForm,
+  ) {
+    const recall = this.getRecall(session, nomsId)
+    recall.returnToCustodyDate = new Date(
+      returnToCustodyDateForm.year as unknown as number,
+      (returnToCustodyDateForm.month as unknown as number) - 1,
+      returnToCustodyDateForm.day as unknown as number,
+    )
+    // eslint-disable-next-line no-param-reassign
+    session.recalls[nomsId] = recall
+  }
+
   private async getSystemClientToken(username: string): Promise<string> {
     return this.hmppsAuthClient.getSystemClientToken(username)
   }
@@ -24,6 +39,9 @@ export default class RecallService {
     const recall = session.recalls[nomsId] ?? ({} as Recall)
     if (recall.recallDate && typeof recall.recallDate === 'string') {
       recall.recallDate = new Date(recall.recallDate)
+    }
+    if (recall.returnToCustodyDate && typeof recall.returnToCustodyDate === 'string') {
+      recall.returnToCustodyDate = new Date(recall.returnToCustodyDate)
     }
     return recall
   }

--- a/server/services/recallService.ts
+++ b/server/services/recallService.ts
@@ -5,8 +5,8 @@ import { HmppsAuthClient } from '../data'
 export default class RecallService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  setRecallDate(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string, recallDateForm: DateForm) {
-    const recall = this.getRecall(session, nomsId)
+  async setRecallDate(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string, recallDateForm: DateForm) {
+    const recall = await this.getRecall(session, nomsId)
     recall.recallDate = new Date(
       recallDateForm.year as unknown as number,
       (recallDateForm.month as unknown as number) - 1,
@@ -16,12 +16,12 @@ export default class RecallService {
     session.recalls[nomsId] = recall
   }
 
-  setReturnToCustodyDate(
+  async setReturnToCustodyDate(
     session: CookieSessionInterfaces.CookieSessionObject,
     nomsId: string,
     returnToCustodyDateForm: DateForm,
   ) {
-    const recall = this.getRecall(session, nomsId)
+    const recall = await this.getRecall(session, nomsId)
     recall.returnToCustodyDate = new Date(
       returnToCustodyDateForm.year as unknown as number,
       (returnToCustodyDateForm.month as unknown as number) - 1,
@@ -35,7 +35,7 @@ export default class RecallService {
     return this.hmppsAuthClient.getSystemClientToken(username)
   }
 
-  getRecall(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string): Recall {
+  async getRecall(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string): Promise<Recall> {
     const recall = session.recalls[nomsId] ?? ({} as Recall)
     if (recall.recallDate && typeof recall.recallDate === 'string') {
       recall.recallDate = new Date(recall.recallDate)

--- a/server/services/recallService.ts
+++ b/server/services/recallService.ts
@@ -5,8 +5,8 @@ import { HmppsAuthClient } from '../data'
 export default class RecallService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  async setRecallDate(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string, recallDateForm: DateForm) {
-    const recall = await this.getRecall(session, nomsId)
+  setRecallDate(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string, recallDateForm: DateForm) {
+    const recall = this.getRecall(session, nomsId)
     recall.recallDate = new Date(
       recallDateForm.year as unknown as number,
       (recallDateForm.month as unknown as number) - 1,
@@ -16,12 +16,12 @@ export default class RecallService {
     session.recalls[nomsId] = recall
   }
 
-  async setReturnToCustodyDate(
+  setReturnToCustodyDate(
     session: CookieSessionInterfaces.CookieSessionObject,
     nomsId: string,
     returnToCustodyDateForm: DateForm,
   ) {
-    const recall = await this.getRecall(session, nomsId)
+    const recall = this.getRecall(session, nomsId)
     recall.returnToCustodyDate = new Date(
       returnToCustodyDateForm.year as unknown as number,
       (returnToCustodyDateForm.month as unknown as number) - 1,
@@ -35,7 +35,7 @@ export default class RecallService {
     return this.hmppsAuthClient.getSystemClientToken(username)
   }
 
-  async getRecall(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string): Promise<Recall> {
+  getRecall(session: CookieSessionInterfaces.CookieSessionObject, nomsId: string): Recall {
     const recall = session.recalls[nomsId] ?? ({} as Recall)
     if (recall.recallDate && typeof recall.recallDate === 'string') {
       recall.recallDate = new Date(recall.recallDate)

--- a/server/views/pages/recallEntry/check-your-answers.njk
+++ b/server/views/pages/recallEntry/check-your-answers.njk
@@ -10,18 +10,27 @@
       {{ govukSummaryList({
         rows: [
           {
-            key: {
-            text: "Recall Date"
-          },
-            value: {
-            text: recall.recallDate
-          },
+            key: { text: "Recall Date" },
+            value: { text: recall.recallDate },
             actions: {
             items: [
               {
                 href: '/person/' + nomsId + '/recall-entry/enter-recall-date?submitToCheckAnswers=true',
                 text: "Edit",
                 visuallyHiddenText: "Recall date"
+              }
+            ]
+          }
+          },
+          {
+            key: { text: "Return to Custody Date" },
+            value: { text: recall.returnToCustodyDate },
+            actions: {
+            items: [
+              {
+                href: '/person/' + nomsId + '/recall-entry/enter-return-to-custody-date?submitToCheckAnswers=true',
+                text: "Edit",
+                visuallyHiddenText: "Return to Custody date"
               }
             ]
           }

--- a/server/views/pages/recallEntry/enter-return-to-custody-date.njk
+++ b/server/views/pages/recallEntry/enter-return-to-custody-date.njk
@@ -5,7 +5,7 @@
 
 {% block content %}
   <form method="post"
-        action="/person/{{ nomsId }}/recall-entry/check-sentences{{ "?submitToCheckAnswers=true" if submitToCheckAnswers }}">
+        action="/person/{{ nomsId }}/recall-entry/enter-return-to-custody-date{{ "?submitToCheckAnswers=true" if submitToCheckAnswers }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}">
     {{ govukDateInput({
       id: "returnToCustodyDate",

--- a/server/views/pages/recallEntry/enter-return-to-custody-date.njk
+++ b/server/views/pages/recallEntry/enter-return-to-custody-date.njk
@@ -4,28 +4,56 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
-  {{ govukDateInput({
-    id: "returnToCustodyDate",
-    namePrefix: "returnToCustodyDate",
-    fieldset: {
-      legend: {
-        text: "What date was this person returned to custody?",
-        isPageHeading: true,
-        classes: "govuk-fieldset__legend--l"
+  <form method="post"
+        action="/person/{{ nomsId }}/recall-entry/check-sentences{{ "?submitToCheckAnswers=true" if submitToCheckAnswers }}">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    {{ govukDateInput({
+      id: "returnToCustodyDate",
+      fieldset: {
+        legend: {
+          text: "What date was this person returned to custody?",
+          isPageHeading: true,
+          classes: "govuk-fieldset__legend--l"
+        }
+      },
+      items: [
+        {
+          id: 'returnToCustodyDateDay',
+          label: 'Day',
+          name: "returnToCustodyDate[day]",
+          value: recall.returnToCustodyDate.getDate() if (recall and recall.returnToCustodyDate),
+          classes: "govuk-input--width-2",
+          attributes: { 'maxlength': 2 }
+        },
+        {
+          id: 'returnToCustodyDateMonth',
+          label: 'Month',
+          name: "returnToCustodyDate[month]",
+          value: recall.returnToCustodyDate.getMonth() + 1 if (recall and recall.returnToCustodyDate),
+          classes: "govuk-input--width-2",
+          attributes: { 'maxlength': 2 }
+        },
+        {
+          id: 'returnToCustodyDateYear',
+          label: 'Year',
+          name: "returnToCustodyDate[year]",
+          value: recall.returnToCustodyDate.getFullYear() if (recall and recall.returnToCustodyDate),
+          classes: "govuk-input--width-4",
+          attributes: { 'maxlength': 4 }
+        }
+      ],
+      hint: {
+        text: "For example, 27 3 2022"
       }
-    },
-    hint: {
-      text: "For example, 27 3 2022"
-    }
-  }) }}
-
-  <div class="govuk-button-group">
-    {{ govukButton({
-      text: "Continue",
-      type: submit,
-      preventDoubleClick: true,
-      href: '/person/' + nomsId + '/recall-entry/check-sentences',
-      attributes: { 'data-qa': 'submit-return-to-custody-date' }
     }) }}
-  </div>
+
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: "Continue",
+        type: submit,
+        preventDoubleClick: true,
+        attributes: { 'data-qa': 'submit-return-to-custody-date' }
+      }) }}
+    </div>
+  </form>
 {% endblock %}


### PR DESCRIPTION
This is WIP and will be iterated on in the next stories, at the moment only two data-entry fields are maintained in the session object and the check-your-answers page 

TODO - add other fields to check your answers and session object (next work)