### PR TITLE
RCLL-97 Add all sentence and calc breakdown information to check-sentence page to aid analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "express-session": "^1.18.0",
         "govuk-frontend": "^5.4.1",
         "helmet": "^7.1.0",
-        "hmpps-court-cases-release-dates-design": "^2.6.2",
+        "hmpps-court-cases-release-dates-design": "^2.7.0",
         "http-errors": "^2.0.0",
         "joi": "^17.13.3",
         "jwt-decode": "^4.0.0",
@@ -7555,9 +7555,10 @@
       }
     },
     "node_modules/hmpps-court-cases-release-dates-design": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-2.6.2.tgz",
-      "integrity": "sha512-6pH/7tYWGgiRTK6SQ0DoFfl+VEuHFe/zNELA2QK5kfcqq1Fk1cePSLKfRl70XkftyyOU3avLmZ+EDZuN7/g6Uw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-2.7.0.tgz",
+      "integrity": "sha512-ApVpFB+wANah0vihLsffWqwpH2SAfGcpeJu2FTpaH4aj4qW0xexCWVsZqASNIZPBhhpGNO9fq4EN+lL8udamqQ==",
+      "license": "MIT",
       "dependencies": {
         "date-fns": "^3.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "express-session": "^1.18.0",
     "govuk-frontend": "^5.4.1",
     "helmet": "^7.1.0",
-    "hmpps-court-cases-release-dates-design": "^2.6.2",
+    "hmpps-court-cases-release-dates-design": "^2.7.0",
     "http-errors": "^2.0.0",
     "joi": "^17.13.3",
     "jwt-decode": "^4.0.0",

--- a/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
+++ b/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
@@ -3,4 +3,5 @@ import { components } from './index'
 export type AnalysedSentenceAndOffence = components['schemas']['AnalysedSentenceAndOffence']
 export type LatestCalculation = components['schemas']['LatestCalculation']
 export type CalculationBreakdown = components['schemas']['CalculationBreakdown']
-export type SentenceAndOffenceWithReleaseArrangements = components['schemas']['SentenceAndOffenceWithReleaseArrangements']
+export type SentenceAndOffenceWithReleaseArrangements =
+  components['schemas']['SentenceAndOffenceWithReleaseArrangements']

--- a/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
+++ b/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
@@ -1,3 +1,5 @@
 import { components } from './index'
 
 export type AnalysedSentenceAndOffence = components['schemas']['AnalysedSentenceAndOffence']
+export type LatestCalculation = components['schemas']['LatestCalculation']
+export type CalculationBreakdown = components['schemas']['CalculationBreakdown']

--- a/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
+++ b/server/@types/calculateReleaseDatesApi/calculateReleaseDatesTypes.ts
@@ -3,3 +3,4 @@ import { components } from './index'
 export type AnalysedSentenceAndOffence = components['schemas']['AnalysedSentenceAndOffence']
 export type LatestCalculation = components['schemas']['LatestCalculation']
 export type CalculationBreakdown = components['schemas']['CalculationBreakdown']
+export type SentenceAndOffenceWithReleaseArrangements = components['schemas']['SentenceAndOffenceWithReleaseArrangements']

--- a/server/api/calculateReleaseDatesApiClient.ts
+++ b/server/api/calculateReleaseDatesApiClient.ts
@@ -1,6 +1,10 @@
 import config, { ApiConfig } from '../config'
 import RestClient from '../data/restClient'
-import { AnalysedSentenceAndOffence } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
+import {
+  AnalysedSentenceAndOffence,
+  CalculationBreakdown,
+  LatestCalculation,
+} from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
 
 export default class CalculateReleaseDatesApiClient {
   restClient: RestClient
@@ -17,5 +21,15 @@ export default class CalculateReleaseDatesApiClient {
     return this.restClient.get({
       path: `/sentence-and-offence-information/${bookingId}`,
     }) as Promise<AnalysedSentenceAndOffence[]>
+  }
+
+  async getLatestCalculation(nomsId: string): Promise<LatestCalculation> {
+    return this.restClient.get({ path: `/calculation/${nomsId}/latest` }) as Promise<LatestCalculation>
+  }
+
+  async getCalculationBreakdown(calculationRequestId: number): Promise<CalculationBreakdown> {
+    return this.restClient.get({
+      path: `/calculation/breakdown/${calculationRequestId}`,
+    }) as Promise<CalculationBreakdown>
   }
 }

--- a/server/api/calculateReleaseDatesApiClient.ts
+++ b/server/api/calculateReleaseDatesApiClient.ts
@@ -4,6 +4,7 @@ import {
   AnalysedSentenceAndOffence,
   CalculationBreakdown,
   LatestCalculation,
+  SentenceAndOffenceWithReleaseArrangements,
 } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
 
 export default class CalculateReleaseDatesApiClient {
@@ -31,5 +32,13 @@ export default class CalculateReleaseDatesApiClient {
     return this.restClient.get({
       path: `/calculation/breakdown/${calculationRequestId}`,
     }) as Promise<CalculationBreakdown>
+  }
+
+  async getSentencesAndReleaseDates(
+    calculationRequestId: number,
+  ): Promise<SentenceAndOffenceWithReleaseArrangements[]> {
+    return this.restClient.get({
+      path: `/calculation/sentence-and-offences/${calculationRequestId}`,
+    }) as Promise<SentenceAndOffenceWithReleaseArrangements[]>
   }
 }

--- a/server/api/calculateReleaseDatesApiClient.ts
+++ b/server/api/calculateReleaseDatesApiClient.ts
@@ -18,12 +18,6 @@ export default class CalculateReleaseDatesApiClient {
     )
   }
 
-  async getActiveAnalyzedSentencesAndOffences(bookingId: number): Promise<AnalysedSentenceAndOffence[]> {
-    return this.restClient.get({
-      path: `/sentence-and-offence-information/${bookingId}`,
-    }) as Promise<AnalysedSentenceAndOffence[]>
-  }
-
   async getLatestCalculation(nomsId: string): Promise<LatestCalculation> {
     return this.restClient.get({ path: `/calculation/${nomsId}/latest` }) as Promise<LatestCalculation>
   }

--- a/server/api/calculateReleaseDatesApiClient.ts
+++ b/server/api/calculateReleaseDatesApiClient.ts
@@ -1,7 +1,6 @@
 import config, { ApiConfig } from '../config'
 import RestClient from '../data/restClient'
 import {
-  AnalysedSentenceAndOffence,
   CalculationBreakdown,
   LatestCalculation,
   SentenceAndOffenceWithReleaseArrangements,

--- a/server/routes/recallEntryRoutes.test.ts
+++ b/server/routes/recallEntryRoutes.test.ts
@@ -351,33 +351,14 @@ describe('GET /person/:nomsId/recall-entry/check-sentences', () => {
         caseSequence: 1,
         caseReference: null,
       },
-    } as CalculationBreakdown)
+    } as unknown as CalculationBreakdown)
 
     return request(app)
       .get('/person/123/recall-entry/check-sentences')
       .expect('Content-Type', /html/)
       .expect(res => {
         // Verify concurrent sentences
-        expect(res.text).toContain('An Offence Name') // Offence name placeholder
-        expect(res.text).toContain('27 06 2024') // Example date
-        expect(res.text).toContain('27 08 2024') // Example date
-        expect(res.text).toContain('Imprisonment')
-        expect(res.text).toContain('1 years 2 months 3 weeks 4 days')
-        expect(res.text).toContain('5 years 6 months 7 weeks 8 days')
-        expect(res.text).toContain('SDS (Standard Determinate Sentence)')
-        expect(res.text).toContain('Edit')
-        expect(res.text).toContain('Delete')
-
-        // Verify consecutive sentence
-        expect(res.text).toContain('An Offence Name') // Offence name placeholder
-        expect(res.text).toContain('27 06 2024') // Example date
-        expect(res.text).toContain('27 08 2024') // Example date
-        expect(res.text).toContain('Imprisonment')
-        expect(res.text).toContain('1 years 2 months 3 weeks 4 days')
-        expect(res.text).toContain('5 years 6 months 7 weeks 8 days')
-        expect(res.text).toContain('SDS (Standard Determinate Sentence)')
-        expect(res.text).toContain('Edit')
-        expect(res.text).toContain('Delete')
+        expect(res.text).toContain('Calculation Breakdown Lookup from CRD')
         expect(auditService.logPageView).toHaveBeenCalledWith(Page.CHECK_SENTENCES, {
           who: user.username,
           correlationId: expect.any(String),

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -1,6 +1,5 @@
 import { RequestHandler } from 'express'
 import type { DateForm } from 'forms'
-import { PrisonerSearchApiPrisoner } from '../@types/prisonerSearchApi/prisonerSearchTypes'
 import PrisonerService from '../services/prisonerService'
 import RecallService from '../services/recallService'
 import { RecallTypes } from '../@types/refData'

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -87,11 +87,6 @@ export default class RecallEntryRoutes {
 
   public getCheckSentences: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
-    const prisoner = res.locals.prisoner as PrisonerSearchApiPrisoner
-    const sentences = await this.prisonerService.getActiveAnalyzedSentencesAndOffences(
-      prisoner.bookingId as unknown as number,
-      res.locals.user.username,
-    )
     const calculationBreakdown = await this.prisonerService.getCalculationBreakdown(nomsId, res.locals.user.username)
     const sentencesAndReleaseDates = await this.prisonerService.getSentencesAndReleaseDates(
       nomsId,
@@ -100,7 +95,6 @@ export default class RecallEntryRoutes {
     return res.render('pages/recallEntry/check-sentences', {
       nomsId,
       calculationBreakdown,
-      sentences,
       sentencesAndReleaseDates,
     })
   }

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -87,8 +87,22 @@ export default class RecallEntryRoutes {
 
   public getCheckSentences: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
+    const prisoner = res.locals.prisoner as PrisonerSearchApiPrisoner
+    const sentences = await this.prisonerService.getActiveAnalyzedSentencesAndOffences(
+      prisoner.bookingId as unknown as number,
+      res.locals.user.username,
+    )
     const calculationBreakdown = await this.prisonerService.getCalculationBreakdown(nomsId, res.locals.user.username)
-    return res.render('pages/recallEntry/check-sentences', { nomsId, calculationBreakdown })
+    const sentencesAndReleaseDates = await this.prisonerService.getSentencesAndReleaseDates(
+      nomsId,
+      res.locals.user.username,
+    )
+    return res.render('pages/recallEntry/check-sentences', {
+      nomsId,
+      calculationBreakdown,
+      sentences,
+      sentencesAndReleaseDates,
+    })
   }
 
   public getEnterRecallType: RequestHandler = async (req, res): Promise<void> => {

--- a/server/routes/recallEntryRoutes.ts
+++ b/server/routes/recallEntryRoutes.ts
@@ -87,12 +87,8 @@ export default class RecallEntryRoutes {
 
   public getCheckSentences: RequestHandler = async (req, res): Promise<void> => {
     const { nomsId } = req.params
-    const prisoner = res.locals.prisoner as PrisonerSearchApiPrisoner
-    const sentences = await this.prisonerService.getActiveAnalyzedSentencesAndOffences(
-      prisoner.bookingId as unknown as number,
-      res.locals.user.username,
-    )
-    return res.render('pages/recallEntry/check-sentences', { nomsId, sentences })
+    const calculationBreakdown = await this.prisonerService.getCalculationBreakdown(nomsId, res.locals.user.username)
+    return res.render('pages/recallEntry/check-sentences', { nomsId, calculationBreakdown })
   }
 
   public getEnterRecallType: RequestHandler = async (req, res): Promise<void> => {

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -4,7 +4,7 @@ import { HmppsAuthClient } from '../data'
 import { PrisonerSearchApiPrisoner } from '../@types/prisonerSearchApi/prisonerSearchTypes'
 import PrisonApiClient from '../api/prisonApiClient'
 import CalculateReleaseDatesApiClient from '../api/calculateReleaseDatesApiClient'
-import { AnalysedSentenceAndOffence } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
+import { CalculationBreakdown } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
 
 export default class PrisonerService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
@@ -17,14 +17,10 @@ export default class PrisonerService {
     return new PrisonApiClient(await this.getSystemClientToken(username)).getPrisonerImage(nomsId)
   }
 
-  async getActiveAnalyzedSentencesAndOffences(
-    bookingId: number,
-    username: string,
-  ): Promise<AnalysedSentenceAndOffence[]> {
+  async getCalculationBreakdown(nomsId: string, username: string): Promise<CalculationBreakdown> {
     const crdApi = await this.getCRDApiClient(username)
-    const sentences = await crdApi.getActiveAnalyzedSentencesAndOffences(bookingId)
-
-    return sentences.filter((s: AnalysedSentenceAndOffence) => s.sentenceStatus === 'A')
+    const latestCalculation = await crdApi.getLatestCalculation(nomsId)
+    return crdApi.getCalculationBreakdown(latestCalculation.calculationRequestId)
   }
 
   private async getCRDApiClient(username: string) {

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -9,6 +9,7 @@ import {
   SentenceAndOffenceWithReleaseArrangements,
   AnalysedSentenceAndOffence,
 } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
+import logger from '../../logger'
 
 export default class PrisonerService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
@@ -31,10 +32,15 @@ export default class PrisonerService {
     return sentences.filter((s: AnalysedSentenceAndOffence) => s.sentenceStatus === 'A')
   }
 
-  async getCalculationBreakdown(nomsId: string, username: string): Promise<CalculationBreakdown> {
-    const crdApi = await this.getCRDApiClient(username)
-    const latestCalculation = await crdApi.getLatestCalculation(nomsId)
-    return crdApi.getCalculationBreakdown(latestCalculation.calculationRequestId)
+  async getCalculationBreakdown(nomsId: string, username: string): Promise<CalculationBreakdown | undefined> {
+    try {
+      const crdApi = await this.getCRDApiClient(username)
+      const latestCalculation = await crdApi.getLatestCalculation(nomsId)
+      return await crdApi.getCalculationBreakdown(latestCalculation.calculationRequestId)
+    } catch (error) {
+      logger.error(`Error in getCalculationBreakdown: ${error.message}`, error)
+      return undefined
+    }
   }
 
   async getSentencesAndReleaseDates(

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -7,7 +7,6 @@ import CalculateReleaseDatesApiClient from '../api/calculateReleaseDatesApiClien
 import {
   CalculationBreakdown,
   SentenceAndOffenceWithReleaseArrangements,
-  AnalysedSentenceAndOffence,
 } from '../@types/calculateReleaseDatesApi/calculateReleaseDatesTypes'
 import logger from '../../logger'
 

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -22,16 +22,6 @@ export default class PrisonerService {
     return new PrisonApiClient(await this.getSystemClientToken(username)).getPrisonerImage(nomsId)
   }
 
-  async getActiveAnalyzedSentencesAndOffences(
-    bookingId: number,
-    username: string,
-  ): Promise<AnalysedSentenceAndOffence[]> {
-    const crdApi = await this.getCRDApiClient(username)
-    const sentences = await crdApi.getActiveAnalyzedSentencesAndOffences(bookingId)
-
-    return sentences.filter((s: AnalysedSentenceAndOffence) => s.sentenceStatus === 'A')
-  }
-
   async getCalculationBreakdown(nomsId: string, username: string): Promise<CalculationBreakdown | undefined> {
     try {
       const crdApi = await this.getCRDApiClient(username)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,6 +7,7 @@ import {
   personDateOfBirth,
   personStatus,
   firstNameSpaceLastName,
+  formatLengths,
 } from 'hmpps-court-cases-release-dates-design/hmpps/utils/utils'
 import dayjs from 'dayjs'
 import { initialiseName } from './utils'
@@ -55,4 +56,5 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('personStatus', personStatus)
   njkEnv.addFilter('firstNameSpaceLastName', firstNameSpaceLastName)
   njkEnv.addFilter('date', (date, format = 'DD MMM YYYY') => dayjs(date).format(format))
+  njkEnv.addFilter('formatLengths', formatLengths)
 }

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -8,7 +8,7 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
-  <h2 class="govuk-heading-m" id="breakdown-info">Calculation breakdown Lookup from CRD</h2>
+  <h2 class="govuk-heading-m" id="breakdown-info">Calculation Breakdown Lookup from CRD</h2>
   <p><a href="#sentence-info" class="govuk-link">Go to Sentences and Offences</a></p>
 
   {% if calculationBreakdown %}

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -275,12 +275,111 @@
       </table>
     {% endif %}
 
-    <!-- ERSED Not Applicable Due to DTO Later Than CRD -->
-    <p class="govuk-body">
-      ERSED Not Applicable Due to DTO Later Than CRD: {{ calculationBreakdown.ersedNotApplicableDueToDtoLaterThanCrd }}
-    </p>
+  {% endif %}
+
+  {% if sentencesAndReleaseDates.length %}
+
+    {% for sentence in sentencesAndReleaseDates %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Sentence and Offence Details</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Booking ID</th>
+          <th scope="col" class="govuk-table__header">Sentence Sequence</th>
+          <th scope="col" class="govuk-table__header">Line Sequence</th>
+          <th scope="col" class="govuk-table__header">Case Sequence</th>
+          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
+          <th scope="col" class="govuk-table__header">Sentence Status</th>
+          <th scope="col" class="govuk-table__header">Sentence Category</th>
+          <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
+          <th scope="col" class="govuk-table__header">Sentence Type Description</th>
+          <th scope="col" class="govuk-table__header">Sentence Date</th>
+          <th scope="col" class="govuk-table__header">Case Reference</th>
+          <th scope="col" class="govuk-table__header">Court Description</th>
+          <th scope="col" class="govuk-table__header">Fine Amount</th>
+          <th scope="col" class="govuk-table__header">Is SDS Plus</th>
+          <th scope="col" class="govuk-table__header">Has SDS Early Release Exclusion</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.bookingId }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceCategory }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
+          <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
+          <td class="govuk-table__cell">{{ sentence.courtDescription }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.fineAmount }}</td>
+          <td class="govuk-table__cell">{{ sentence.isSDSPlus }}</td>
+          <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion }}</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <!-- Sentence Terms -->
+      {% if sentence.terms.length %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Years</th>
+            <th scope="col" class="govuk-table__header">Months</th>
+            <th scope="col" class="govuk-table__header">Weeks</th>
+            <th scope="col" class="govuk-table__header">Days</th>
+            <th scope="col" class="govuk-table__header">Term Code</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          {% for term in sentence.terms %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
+              <td class="govuk-table__cell">{{ term.code }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+
+      <!-- Offence Details -->
+      {% if sentence.offence %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Offender Charge ID</th>
+            <th scope="col" class="govuk-table__header">Offence Start Date</th>
+            <th scope="col" class="govuk-table__header">Offence End Date</th>
+            <th scope="col" class="govuk-table__header">Offence Code</th>
+            <th scope="col" class="govuk-table__header">Offence Description</th>
+            <th scope="col" class="govuk-table__header">Indicators</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.indicators | join(', ') }}</td>
+          </tr>
+          </tbody>
+        </table>
+      {% endif %}
+
+    {% endfor %}
 
   {% endif %}
+
 
 
   <div class="govuk-button-group">

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -8,93 +8,103 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
-  {% from "hmpps/components/court-cases-release-dates/offence-card/macro.njk" import offenceCard %}
+  {% for sentence in sentences %}
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Booking ID</th>
+        <th scope="col" class="govuk-table__header">Sentence Sequence</th>
+        <th scope="col" class="govuk-table__header">Line Sequence</th>
+        <th scope="col" class="govuk-table__header">Case Sequence</th>
+        {% if sentence.consecutiveToSequence %}
+          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
+        {% endif %}
+        <th scope="col" class="govuk-table__header">Sentence Status</th>
+        <th scope="col" class="govuk-table__header">Sentence Category</th>
+        <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
+        <th scope="col" class="govuk-table__header">Sentence Type Description</th>
+        <th scope="col" class="govuk-table__header">Sentence Date</th>
+        <th scope="col" class="govuk-table__header">Case Reference</th>
+        <th scope="col" class="govuk-table__header">Court Description</th>
+        <th scope="col" class="govuk-table__header">Fine Amount</th>
+        <th scope="col" class="govuk-table__header">Sentence and Offence Analysis</th>
+        <th scope="col" class="govuk-table__header">Is SDS Plus?</th>
+        <th scope="col" class="govuk-table__header">SDS Early Release Exclusion</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.bookingId }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
+        {% if sentence.consecutiveToSequence %}
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
+        {% endif %}
+        <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceCategory }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
+        <td class="govuk-table__cell">{{ sentence.courtDescription }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.fineAmount }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceAndOffenceAnalysis }}</td>
+        <td class="govuk-table__cell">{{ sentence.isSDSPlus ? 'Yes' : 'No' }}</td>
+        <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion }}</td>
+      </tr>
+      </tbody>
+    </table>
 
-  {# Concurrent Sentences #}
-  {% for sentence in calculationBreakdown.concurrentSentences %}
-    {{ offenceCard({
-      offenceCode: 'OFFENCECODE',
-      offenceName: 'An Offence Name',
-      offenceStartDate: '27 06 2024',
-      offenceEndDate: '27 08 2024',
-      outcome: 'Imprisonment',
-      countNumber: sentence.lineSequence,
-      terrorRelated: false,
-      isSentenced: true,
-      custodialSentenceLength: {
-        years: '1',
-        months: '2',
-        weeks: '3',
-        days: '4',
-        periodOrder: ['years', 'months', 'weeks', 'days']
-      },
-      licencePeriodLength: {
-        years: '5',
-        months: '6',
-        weeks: '7',
-        days: '8',
-        periodOrder: ['years', 'months', 'weeks', 'days']
-      },
-      sentenceServeType: 'CONCURRENT',
-      consecutiveTo: 'N/A',
-      sentenceType: 'SDS (Standard Determinate Sentence)',
-      actions: {
-        items: [
-          {
-            text: 'Edit',
-            href: '/edit'
-          },
-          {
-            text: 'Delete',
-            href: '/delete'
-          }
-        ]
-      }
-    }) }}
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Offender Charge ID</th>
+        <th scope="col" class="govuk-table__header">Offence Start Date</th>
+        <th scope="col" class="govuk-table__header">Offence End Date</th>
+        <th scope="col" class="govuk-table__header">Offence Code</th>
+        <th scope="col" class="govuk-table__header">Offence Description</th>
+        <th scope="col" class="govuk-table__header">Indicators</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.indicators | join(', ') }}</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Years</th>
+        <th scope="col" class="govuk-table__header">Months</th>
+        <th scope="col" class="govuk-table__header">Weeks</th>
+        <th scope="col" class="govuk-table__header">Days</th>
+        <th scope="col" class="govuk-table__header">Code</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      {% for term in sentence.terms %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
+          <td class="govuk-table__cell">{{ term.code }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
   {% endfor %}
-
-  {# Consecutive Sentences #}
-  {% if calculationBreakdown.consecutiveSentence %}
-    {{ offenceCard({
-      offenceCode: 'OFFENCECODE',
-      offenceName: 'An Offence Name',
-      offenceStartDate: '27 06 2024',
-      offenceEndDate: '27 08 2024',
-      outcome: 'Imprisonment',
-      countNumber: 1,
-      terrorRelated: false,
-      isSentenced: true,
-      custodialSentenceLength: {
-        years: '1',
-        months: '2',
-        weeks: '3',
-        days: '4',
-        periodOrder: ['years', 'months', 'weeks', 'days']
-      },
-      licencePeriodLength: {
-        years: '5',
-        months: '6',
-        weeks: '7',
-        days: '8',
-        periodOrder: ['years', 'months', 'weeks', 'days']
-      },
-      sentenceServeType: 'CONSECUTIVE',
-      consecutiveTo: 'N/A',
-      sentenceType: 'SDS (Standard Determinate Sentence)',
-      actions: {
-        items: [
-          {
-            text: 'Edit',
-            href: '/edit'
-          },
-          {
-            text: 'Delete',
-            href: '/delete'
-          }
-        ]
-      }
-    }) }}
-  {% endif %}
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -90,6 +90,199 @@
     </table>
   {% endfor %}
 
+  {% if calculationBreakdown %}
+
+    <!-- Concurrent Sentences -->
+    {% if calculationBreakdown.concurrentSentences.length %}
+      {% for concurrentSentence in calculationBreakdown.concurrentSentences %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Concurrent Sentence Details</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Line Sequence</th>
+            <th scope="col" class="govuk-table__header">Case Sequence</th>
+            <th scope="col" class="govuk-table__header">Sentenced At</th>
+            <th scope="col" class="govuk-table__header">Sentence Length</th>
+            <th scope="col" class="govuk-table__header">Sentence Length (Days)</th>
+            <th scope="col" class="govuk-table__header">Case Reference</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{ concurrentSentence.lineSequence }}</td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{ concurrentSentence.caseSequence }}</td>
+            <td class="govuk-table__cell">{{ concurrentSentence.sentencedAt }}</td>
+            <td class="govuk-table__cell">{{ concurrentSentence.sentenceLength }}</td>
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{ concurrentSentence.sentenceLengthDays }}</td>
+            <td class="govuk-table__cell">{{ concurrentSentence.caseReference }}</td>
+          </tr>
+          </tbody>
+        </table>
+
+        <!-- Dates Breakdown -->
+        {% if concurrentSentence.dates %}
+          <table class="govuk-table">
+            <caption class="govuk-table__caption govuk-table__caption--m">Concurrent Sentence Dates Breakdown</caption>
+            <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Date Type</th>
+              <th scope="col" class="govuk-table__header">Unadjusted</th>
+              <th scope="col" class="govuk-table__header">Adjusted</th>
+              <th scope="col" class="govuk-table__header">Days from Sentence Start</th>
+              <th scope="col" class="govuk-table__header">Adjusted by Days</th>
+            </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+            {% for dateType, dateBreakdown in concurrentSentence.dates %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ dateType }}</td>
+                <td class="govuk-table__cell">{{ dateBreakdown.unadjusted }}</td>
+                <td class="govuk-table__cell">{{ dateBreakdown.adjusted }}</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">{{ dateBreakdown.daysFromSentenceStart }}</td>
+                <td class="govuk-table__cell govuk-table__cell--numeric">{{ dateBreakdown.adjustedByDays }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    <!-- Consecutive Sentence -->
+    {% if calculationBreakdown.consecutiveSentence %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Consecutive Sentence Details</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Sentenced At</th>
+          <th scope="col" class="govuk-table__header">Sentence Length</th>
+          <th scope="col" class="govuk-table__header">Sentence Length (Days)</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ calculationBreakdown.consecutiveSentence.sentencedAt }}</td>
+          <td class="govuk-table__cell">{{ calculationBreakdown.consecutiveSentence.sentenceLength }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ calculationBreakdown.consecutiveSentence.sentenceLengthDays }}</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <!-- Consecutive Sentence Parts -->
+      {% if calculationBreakdown.consecutiveSentence.sentenceParts.length %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Consecutive Sentence Parts</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Line Sequence</th>
+            <th scope="col" class="govuk-table__header">Case Sequence</th>
+            <th scope="col" class="govuk-table__header">Sentence Length</th>
+            <th scope="col" class="govuk-table__header">Consecutive To Line Sequence</th>
+            <th scope="col" class="govuk-table__header">Consecutive To Case Sequence</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          {% for part in calculationBreakdown.consecutiveSentence.sentenceParts %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ part.lineSequence }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ part.caseSequence }}</td>
+              <td class="govuk-table__cell">{{ part.sentenceLength }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ part.consecutiveToLineSequence }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ part.consecutiveToCaseSequence }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+
+      <!-- Dates Breakdown -->
+      {% if calculationBreakdown.consecutiveSentence.dates %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Consecutive Sentence Dates Breakdown</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Date Type</th>
+            <th scope="col" class="govuk-table__header">Unadjusted</th>
+            <th scope="col" class="govuk-table__header">Adjusted</th>
+            <th scope="col" class="govuk-table__header">Days from Sentence Start</th>
+            <th scope="col" class="govuk-table__header">Adjusted by Days</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          {% for dateType, dateBreakdown in calculationBreakdown.consecutiveSentence.dates %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ dateType }}</td>
+              <td class="govuk-table__cell">{{ dateBreakdown.unadjusted }}</td>
+              <td class="govuk-table__cell">{{ dateBreakdown.adjusted }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ dateBreakdown.daysFromSentenceStart }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ dateBreakdown.adjustedByDays }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% endif %}
+
+    <!-- Breakdown by Release Date Type -->
+    {% if calculationBreakdown.breakdownByReleaseDateType %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Breakdown by Release Date Type</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Release Date Type</th>
+          <th scope="col" class="govuk-table__header">Unadjusted Date</th>
+          <th scope="col" class="govuk-table__header">Adjusted Date</th>
+          <th scope="col" class="govuk-table__header">Days from Sentence Start</th>
+          <th scope="col" class="govuk-table__header">Adjusted by Days</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for releaseDateType, releaseDateBreakdown in calculationBreakdown.breakdownByReleaseDateType %}
+          {% if releaseDateBreakdown %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ releaseDateType }}</td>
+              <td class="govuk-table__cell">{{ releaseDateBreakdown.unadjusted }}</td>
+              <td class="govuk-table__cell">{{ releaseDateBreakdown.adjusted }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ releaseDateBreakdown.daysFromSentenceStart }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ releaseDateBreakdown.adjustedByDays }}</td>
+            </tr>
+          {% endif %}
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+
+    <!-- Other Dates -->
+    {% if calculationBreakdown.otherDates %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Other Dates</caption>
+        <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Date Type</th>
+          <th scope="col" class="govuk-table__header">Date</th>
+        </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+        {% for dateType, date in calculationBreakdown.otherDates %}
+          {% if date %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ dateType }}</td>
+              <td class="govuk-table__cell">{{ date }}</td>
+            </tr>
+          {% endif %}
+        {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+
+    <!-- ERSED Not Applicable Due to DTO Later Than CRD -->
+    <p class="govuk-body">
+      ERSED Not Applicable Due to DTO Later Than CRD: {{ calculationBreakdown.ersedNotApplicableDueToDtoLaterThanCrd }}
+    </p>
+
+  {% endif %}
+
+
   <div class="govuk-button-group">
     {{ govukButton({
       text: "Continue",

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -52,7 +52,6 @@
         <th scope="col" class="govuk-table__header">Offence End Date</th>
         <th scope="col" class="govuk-table__header">Offence Code</th>
         <th scope="col" class="govuk-table__header">Offence Description</th>
-        <th scope="col" class="govuk-table__header">Indicators</th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -62,7 +61,6 @@
         <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
         <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
         <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.indicators | join(', ') }}</td>
       </tr>
       </tbody>
     </table>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -51,7 +51,7 @@
         <td class="govuk-table__cell">{{ sentence.courtDescription }}</td>
         <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.fineAmount }}</td>
         <td class="govuk-table__cell">{{ sentence.sentenceAndOffenceAnalysis }}</td>
-        <td class="govuk-table__cell">{{ sentence.isSDSPlus ? 'Yes' : 'No' }}</td>
+        <td class="govuk-table__cell">{{ sentence.isSDSPlus }}</td>
         <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion }}</td>
       </tr>
       </tbody>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -13,29 +13,21 @@
       <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Booking ID</th>
-        <th scope="col" class="govuk-table__header">Sentence Sequence</th>
+        <th scope="col" class="govuk-table__header">Sequence</th>
         <th scope="col" class="govuk-table__header">Line Sequence</th>
         <th scope="col" class="govuk-table__header">Case Sequence</th>
         {% if sentence.consecutiveToSequence %}
           <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
         {% endif %}
-        <th scope="col" class="govuk-table__header">Sentence Status</th>
-        <th scope="col" class="govuk-table__header">Sentence Category</th>
-        <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
-        <th scope="col" class="govuk-table__header">Sentence Type Description</th>
+        <th scope="col" class="govuk-table__header">Status</th>
+        <th scope="col" class="govuk-table__header">Calculation Type</th>
+        <th scope="col" class="govuk-table__header">Type Description</th>
         <th scope="col" class="govuk-table__header">Sentence Date</th>
         <th scope="col" class="govuk-table__header">Case Reference</th>
-        <th scope="col" class="govuk-table__header">Court Description</th>
-        <th scope="col" class="govuk-table__header">Fine Amount</th>
-        <th scope="col" class="govuk-table__header">Sentence and Offence Analysis</th>
-        <th scope="col" class="govuk-table__header">Is SDS Plus?</th>
-        <th scope="col" class="govuk-table__header">SDS Early Release Exclusion</th>
       </tr>
       </thead>
       <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.bookingId }}</td>
         <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
         <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
         <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
@@ -43,16 +35,10 @@
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
         {% endif %}
         <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceCategory }}</td>
         <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
         <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
         <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
         <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
-        <td class="govuk-table__cell">{{ sentence.courtDescription }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.fineAmount }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceAndOffenceAnalysis }}</td>
-        <td class="govuk-table__cell">{{ sentence.isSDSPlus }}</td>
-        <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion }}</td>
       </tr>
       </tbody>
     </table>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -7,91 +7,6 @@
 {% set pageId = "check-information" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
-  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
-  <h2 class="govuk-heading-m">Active Analyzed Sentences and Offences Lookup from CRD</h2>
-  {% for sentence in sentences %}
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Sequence</th>
-        <th scope="col" class="govuk-table__header">Line Sequence</th>
-        <th scope="col" class="govuk-table__header">Case Sequence</th>
-        {% if sentence.consecutiveToSequence %}
-          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
-        {% endif %}
-        <th scope="col" class="govuk-table__header">Status</th>
-        <th scope="col" class="govuk-table__header">Calculation Type</th>
-        <th scope="col" class="govuk-table__header">Description</th>
-        <th scope="col" class="govuk-table__header">Sentence Date</th>
-        <th scope="col" class="govuk-table__header">Case Reference</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
-        {% if sentence.consecutiveToSequence %}
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
-        {% endif %}
-        <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
-      </tr>
-      </tbody>
-    </table>
-
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Offender Charge ID</th>
-        <th scope="col" class="govuk-table__header">Offence Start Date</th>
-        <th scope="col" class="govuk-table__header">Offence End Date</th>
-        <th scope="col" class="govuk-table__header">Offence Code</th>
-        <th scope="col" class="govuk-table__header">Offence Description</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
-      </tr>
-      </tbody>
-    </table>
-
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Years</th>
-        <th scope="col" class="govuk-table__header">Months</th>
-        <th scope="col" class="govuk-table__header">Weeks</th>
-        <th scope="col" class="govuk-table__header">Days</th>
-        <th scope="col" class="govuk-table__header">Code</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      {% for term in sentence.terms %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
-          <td class="govuk-table__cell">{{ term.code }}</td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  {% endfor %}
-
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
   <h2 class="govuk-heading-m">Calculation breakdown Lookup from CRD</h2>
 
@@ -281,6 +196,92 @@
     {% endif %}
 
   {% endif %}
+
+
+  <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
+  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
+  <h2 class="govuk-heading-m">Active Analyzed Sentences and Offences Lookup from CRD</h2>
+  {% for sentence in sentences %}
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Sequence</th>
+        <th scope="col" class="govuk-table__header">Line Sequence</th>
+        <th scope="col" class="govuk-table__header">Case Sequence</th>
+        {% if sentence.consecutiveToSequence %}
+          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
+        {% endif %}
+        <th scope="col" class="govuk-table__header">Status</th>
+        <th scope="col" class="govuk-table__header">Calculation Type</th>
+        <th scope="col" class="govuk-table__header">Description</th>
+        <th scope="col" class="govuk-table__header">Sentence Date</th>
+        <th scope="col" class="govuk-table__header">Case Reference</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
+        {% if sentence.consecutiveToSequence %}
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
+        {% endif %}
+        <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
+        <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Offender Charge ID</th>
+        <th scope="col" class="govuk-table__header">Offence Start Date</th>
+        <th scope="col" class="govuk-table__header">Offence End Date</th>
+        <th scope="col" class="govuk-table__header">Offence Code</th>
+        <th scope="col" class="govuk-table__header">Offence Description</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
+        <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
+      </tr>
+      </tbody>
+    </table>
+
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
+      <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Years</th>
+        <th scope="col" class="govuk-table__header">Months</th>
+        <th scope="col" class="govuk-table__header">Weeks</th>
+        <th scope="col" class="govuk-table__header">Days</th>
+        <th scope="col" class="govuk-table__header">Code</th>
+      </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      {% for term in sentence.terms %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
+          <td class="govuk-table__cell">{{ term.code }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% endfor %}
 
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
   <h2 class="govuk-heading-m">Sentence and Release Dates Lookup from CRD</h2>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -8,6 +8,8 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
+  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
+  <h2 class="govuk-heading-m">Active Analyzed Sentences and Offences Lookup from CRD</h2>
   {% for sentence in sentences %}
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
@@ -21,7 +23,7 @@
         {% endif %}
         <th scope="col" class="govuk-table__header">Status</th>
         <th scope="col" class="govuk-table__header">Calculation Type</th>
-        <th scope="col" class="govuk-table__header">Type Description</th>
+        <th scope="col" class="govuk-table__header">Description</th>
         <th scope="col" class="govuk-table__header">Sentence Date</th>
         <th scope="col" class="govuk-table__header">Case Reference</th>
       </tr>
@@ -89,6 +91,9 @@
       </tbody>
     </table>
   {% endfor %}
+
+  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
+  <h2 class="govuk-heading-m">Calculation breakdown Lookup from CRD</h2>
 
   {% if calculationBreakdown %}
 
@@ -277,6 +282,8 @@
 
   {% endif %}
 
+  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
+  <h2 class="govuk-heading-m">Sentence and Release Dates Lookup from CRD</h2>
   {% if sentencesAndReleaseDates.length %}
 
     {% for sentence in sentencesAndReleaseDates %}
@@ -284,41 +291,28 @@
         <caption class="govuk-table__caption govuk-table__caption--m">Sentence and Offence Details</caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Booking ID</th>
-          <th scope="col" class="govuk-table__header">Sentence Sequence</th>
+          <th scope="col" class="govuk-table__header">Sequence</th>
           <th scope="col" class="govuk-table__header">Line Sequence</th>
           <th scope="col" class="govuk-table__header">Case Sequence</th>
           <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
-          <th scope="col" class="govuk-table__header">Sentence Status</th>
-          <th scope="col" class="govuk-table__header">Sentence Category</th>
+          <th scope="col" class="govuk-table__header">Status</th>
           <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
           <th scope="col" class="govuk-table__header">Sentence Type Description</th>
           <th scope="col" class="govuk-table__header">Sentence Date</th>
           <th scope="col" class="govuk-table__header">Case Reference</th>
-          <th scope="col" class="govuk-table__header">Court Description</th>
-          <th scope="col" class="govuk-table__header">Fine Amount</th>
-          <th scope="col" class="govuk-table__header">Is SDS Plus</th>
-          <th scope="col" class="govuk-table__header">Has SDS Early Release Exclusion</th>
         </tr>
         </thead>
         <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.bookingId }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
           <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
-          <td class="govuk-table__cell">{{ sentence.sentenceCategory }}</td>
           <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
           <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
           <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
           <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
-          <td class="govuk-table__cell">{{ sentence.courtDescription }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.fineAmount }}</td>
-          <td class="govuk-table__cell">{{ sentence.isSDSPlus }}</td>
-          <td class="govuk-table__cell">{{ sentence.hasAnSDSEarlyReleaseExclusion }}</td>
-        </tr>
         </tbody>
       </table>
 
@@ -360,7 +354,6 @@
             <th scope="col" class="govuk-table__header">Offence End Date</th>
             <th scope="col" class="govuk-table__header">Offence Code</th>
             <th scope="col" class="govuk-table__header">Offence Description</th>
-            <th scope="col" class="govuk-table__header">Indicators</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body">
@@ -370,7 +363,6 @@
             <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
             <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
             <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
-            <td class="govuk-table__cell">{{ sentence.offence.indicators | join(', ') }}</td>
           </tr>
           </tbody>
         </table>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -8,7 +8,6 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
-  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
   <h2 class="govuk-heading-m" id="breakdown-info">Calculation breakdown Lookup from CRD</h2>
   <p><a href="#sentence-info" class="govuk-link">Go to Active Analyzed Sentences and Offences</a></p>
 
@@ -199,91 +198,96 @@
 
   {% endif %}
 
-
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
-  <h2 class="govuk-heading-m" id="sentence-info">Active Analyzed Sentences and Offences Lookup from CRD</h2>
+  <h2 class="govuk-heading-m" id="sentemce-info">Sentence and Release Dates Lookup from CRD</h2>
   <p><a href="#breakdown-info" class="govuk-link">Back to Calculation breakdown</a></p>
-  {% for sentence in sentences %}
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Sequence</th>
-        <th scope="col" class="govuk-table__header">Line Sequence</th>
-        <th scope="col" class="govuk-table__header">Case Sequence</th>
-        {% if sentence.consecutiveToSequence %}
-          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
-        {% endif %}
-        <th scope="col" class="govuk-table__header">Status</th>
-        <th scope="col" class="govuk-table__header">Calculation Type</th>
-        <th scope="col" class="govuk-table__header">Description</th>
-        <th scope="col" class="govuk-table__header">Sentence Date</th>
-        <th scope="col" class="govuk-table__header">Case Reference</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
-        {% if sentence.consecutiveToSequence %}
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
-        {% endif %}
-        <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
-        <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
-      </tr>
-      </tbody>
-    </table>
+  {% if sentencesAndReleaseDates.length %}
 
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Offender Charge ID</th>
-        <th scope="col" class="govuk-table__header">Offence Start Date</th>
-        <th scope="col" class="govuk-table__header">Offence End Date</th>
-        <th scope="col" class="govuk-table__header">Offence Code</th>
-        <th scope="col" class="govuk-table__header">Offence Description</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
-        <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
-      </tr>
-      </tbody>
-    </table>
-
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
-      <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Years</th>
-        <th scope="col" class="govuk-table__header">Months</th>
-        <th scope="col" class="govuk-table__header">Weeks</th>
-        <th scope="col" class="govuk-table__header">Days</th>
-        <th scope="col" class="govuk-table__header">Code</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-      {% for term in sentence.terms %}
+    {% for sentence in sentencesAndReleaseDates %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Sentence and Offence Details</caption>
+        <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
-          <td class="govuk-table__cell">{{ term.code }}</td>
+          <th scope="col" class="govuk-table__header">Sequence</th>
+          <th scope="col" class="govuk-table__header">Line Sequence</th>
+          <th scope="col" class="govuk-table__header">Case Sequence</th>
+          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
+          <th scope="col" class="govuk-table__header">Sentence Type Description</th>
+          <th scope="col" class="govuk-table__header">Sentence Date</th>
+          <th scope="col" class="govuk-table__header">Case Reference</th>
         </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-  {% endfor %}
+        </thead>
+        <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
+          <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
+          <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
+        </tbody>
+      </table>
+
+      <!-- Sentence Terms -->
+      {% if sentence.terms.length %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Years</th>
+            <th scope="col" class="govuk-table__header">Months</th>
+            <th scope="col" class="govuk-table__header">Weeks</th>
+            <th scope="col" class="govuk-table__header">Days</th>
+            <th scope="col" class="govuk-table__header">Term Code</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          {% for term in sentence.terms %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
+              <td class="govuk-table__cell">{{ term.code }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+
+      <!-- Offence Details -->
+      {% if sentence.offence %}
+        <table class="govuk-table">
+          <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Offender Charge ID</th>
+            <th scope="col" class="govuk-table__header">Offence Start Date</th>
+            <th scope="col" class="govuk-table__header">Offence End Date</th>
+            <th scope="col" class="govuk-table__header">Offence Code</th>
+            <th scope="col" class="govuk-table__header">Offence Description</th>
+          </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
+            <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
+          </tr>
+          </tbody>
+        </table>
+      {% endif %}
+
+    {% endfor %}
+
+  {% endif %}
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -9,7 +9,7 @@
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
   <h2 class="govuk-heading-m" id="breakdown-info">Calculation breakdown Lookup from CRD</h2>
-  <p><a href="#sentence-info" class="govuk-link">Go to Active Analyzed Sentences and Offences</a></p>
+  <p><a href="#sentence-info" class="govuk-link">Go to Sentences and Offences</a></p>
 
   {% if calculationBreakdown %}
 
@@ -200,12 +200,11 @@
 
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
   <h2 class="govuk-heading-m" id="sentemce-info">Sentence and Release Dates Lookup from CRD</h2>
-  <p><a href="#breakdown-info" class="govuk-link">Back to Calculation breakdown</a></p>
+  <p><a href="#breakdown-info" class="govuk-link">Go to Calculation breakdown</a></p>
   {% if sentencesAndReleaseDates.length %}
-
     {% for sentence in sentencesAndReleaseDates %}
       <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">Sentence and Offence Details</caption>
+        <caption class="govuk-table__caption govuk-table__caption--m">Sentence {{ sentence.sentenceSequence }} details</caption>
         <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Sequence</th>
@@ -236,7 +235,6 @@
       <!-- Sentence Terms -->
       {% if sentence.terms.length %}
         <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Years</th>
@@ -263,7 +261,6 @@
       <!-- Offence Details -->
       {% if sentence.offence %}
         <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Offender Charge ID</th>

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -7,8 +7,10 @@
 {% set pageId = "check-information" %}
 
 {% block content %}
+  <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
-  <h2 class="govuk-heading-m">Calculation breakdown Lookup from CRD</h2>
+  <h2 class="govuk-heading-m" id="breakdown-info">Calculation breakdown Lookup from CRD</h2>
+  <p><a href="#sentence-info" class="govuk-link">Go to Active Analyzed Sentences and Offences</a></p>
 
   {% if calculationBreakdown %}
 
@@ -198,9 +200,9 @@
   {% endif %}
 
 
-  <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
   <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
-  <h2 class="govuk-heading-m">Active Analyzed Sentences and Offences Lookup from CRD</h2>
+  <h2 class="govuk-heading-m" id="sentence-info">Active Analyzed Sentences and Offences Lookup from CRD</h2>
+  <p><a href="#breakdown-info" class="govuk-link">Back to Calculation breakdown</a></p>
   {% for sentence in sentences %}
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--m">Sentence Details</caption>
@@ -282,98 +284,6 @@
       </tbody>
     </table>
   {% endfor %}
-
-  <div class="govuk-section-break govuk-section-break--xl govuk-section-break--visible"></div>
-  <h2 class="govuk-heading-m">Sentence and Release Dates Lookup from CRD</h2>
-  {% if sentencesAndReleaseDates.length %}
-
-    {% for sentence in sentencesAndReleaseDates %}
-      <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">Sentence and Offence Details</caption>
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Sequence</th>
-          <th scope="col" class="govuk-table__header">Line Sequence</th>
-          <th scope="col" class="govuk-table__header">Case Sequence</th>
-          <th scope="col" class="govuk-table__header">Consecutive To Sequence</th>
-          <th scope="col" class="govuk-table__header">Status</th>
-          <th scope="col" class="govuk-table__header">Sentence Calculation Type</th>
-          <th scope="col" class="govuk-table__header">Sentence Type Description</th>
-          <th scope="col" class="govuk-table__header">Sentence Date</th>
-          <th scope="col" class="govuk-table__header">Case Reference</th>
-        </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.sentenceSequence }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.lineSequence }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.caseSequence }}</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.consecutiveToSequence }}</td>
-          <td class="govuk-table__cell">{{ sentence.sentenceStatus }}</td>
-          <td class="govuk-table__cell">{{ sentence.sentenceCalculationType }}</td>
-          <td class="govuk-table__cell">{{ sentence.sentenceTypeDescription }}</td>
-          <td class="govuk-table__cell">{{ sentence.sentenceDate }}</td>
-          <td class="govuk-table__cell">{{ sentence.caseReference }}</td>
-        </tbody>
-      </table>
-
-      <!-- Sentence Terms -->
-      {% if sentence.terms.length %}
-        <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Sentence Terms</caption>
-          <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Years</th>
-            <th scope="col" class="govuk-table__header">Months</th>
-            <th scope="col" class="govuk-table__header">Weeks</th>
-            <th scope="col" class="govuk-table__header">Days</th>
-            <th scope="col" class="govuk-table__header">Term Code</th>
-          </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-          {% for term in sentence.terms %}
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.years }}</td>
-              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.months }}</td>
-              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.weeks }}</td>
-              <td class="govuk-table__cell govuk-table__cell--numeric">{{ term.days }}</td>
-              <td class="govuk-table__cell">{{ term.code }}</td>
-            </tr>
-          {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
-
-      <!-- Offence Details -->
-      {% if sentence.offence %}
-        <table class="govuk-table">
-          <caption class="govuk-table__caption govuk-table__caption--m">Offence Details</caption>
-          <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Offender Charge ID</th>
-            <th scope="col" class="govuk-table__header">Offence Start Date</th>
-            <th scope="col" class="govuk-table__header">Offence End Date</th>
-            <th scope="col" class="govuk-table__header">Offence Code</th>
-            <th scope="col" class="govuk-table__header">Offence Description</th>
-          </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell govuk-table__cell--numeric">{{ sentence.offence.offenderChargeId }}</td>
-            <td class="govuk-table__cell">{{ sentence.offence.offenceStartDate }}</td>
-            <td class="govuk-table__cell">{{ sentence.offence.offenceEndDate }}</td>
-            <td class="govuk-table__cell">{{ sentence.offence.offenceCode }}</td>
-            <td class="govuk-table__cell">{{ sentence.offence.offenceDescription }}</td>
-          </tr>
-          </tbody>
-        </table>
-      {% endif %}
-
-    {% endfor %}
-
-  {% endif %}
-
-
 
   <div class="govuk-button-group">
     {{ govukButton({

--- a/server/views/pages/recallEntry/check-sentences.njk
+++ b/server/views/pages/recallEntry/check-sentences.njk
@@ -8,27 +8,93 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl" id="check-sentence-heading">Check sentence information</h1>
-  {% for sentence in sentences %}
-    <h2 class="govuk-heading-m">Case reference: {{ sentence.caseReference }}</h2>
+  {% from "hmpps/components/court-cases-release-dates/offence-card/macro.njk" import offenceCard %}
 
-    {{ govukSummaryList({
-      classes: "govuk-!-margin-bottom-9",
-      rows: [
-        {
-          key: { text: "Sentence Type" },
-          value: { text: sentence.sentenceTypeDescription }
-        },
-        {
-          key: { text: "Sentence Date" },
-          value: { text: sentence.sentenceDate }
-        },
-        {
-          key: { text: "Offence" },
-          value: { text: sentence.offence.offenceCode + ' ' + sentence.offence.offenceDescription }
-        }
-      ]
+  {# Concurrent Sentences #}
+  {% for sentence in calculationBreakdown.concurrentSentences %}
+    {{ offenceCard({
+      offenceCode: 'OFFENCECODE',
+      offenceName: 'An Offence Name',
+      offenceStartDate: '27 06 2024',
+      offenceEndDate: '27 08 2024',
+      outcome: 'Imprisonment',
+      countNumber: sentence.lineSequence,
+      terrorRelated: false,
+      isSentenced: true,
+      custodialSentenceLength: {
+        years: '1',
+        months: '2',
+        weeks: '3',
+        days: '4',
+        periodOrder: ['years', 'months', 'weeks', 'days']
+      },
+      licencePeriodLength: {
+        years: '5',
+        months: '6',
+        weeks: '7',
+        days: '8',
+        periodOrder: ['years', 'months', 'weeks', 'days']
+      },
+      sentenceServeType: 'CONCURRENT',
+      consecutiveTo: 'N/A',
+      sentenceType: 'SDS (Standard Determinate Sentence)',
+      actions: {
+        items: [
+          {
+            text: 'Edit',
+            href: '/edit'
+          },
+          {
+            text: 'Delete',
+            href: '/delete'
+          }
+        ]
+      }
     }) }}
   {% endfor %}
+
+  {# Consecutive Sentences #}
+  {% if calculationBreakdown.consecutiveSentence %}
+    {{ offenceCard({
+      offenceCode: 'OFFENCECODE',
+      offenceName: 'An Offence Name',
+      offenceStartDate: '27 06 2024',
+      offenceEndDate: '27 08 2024',
+      outcome: 'Imprisonment',
+      countNumber: 1,
+      terrorRelated: false,
+      isSentenced: true,
+      custodialSentenceLength: {
+        years: '1',
+        months: '2',
+        weeks: '3',
+        days: '4',
+        periodOrder: ['years', 'months', 'weeks', 'days']
+      },
+      licencePeriodLength: {
+        years: '5',
+        months: '6',
+        weeks: '7',
+        days: '8',
+        periodOrder: ['years', 'months', 'weeks', 'days']
+      },
+      sentenceServeType: 'CONSECUTIVE',
+      consecutiveTo: 'N/A',
+      sentenceType: 'SDS (Standard Determinate Sentence)',
+      actions: {
+        items: [
+          {
+            text: 'Edit',
+            href: '/edit'
+          },
+          {
+            text: 'Delete',
+            href: '/delete'
+          }
+        ]
+      }
+    }) }}
+  {% endif %}
 
   <div class="govuk-button-group">
     {{ govukButton({


### PR DESCRIPTION
This is a change to aid analysis (the final screen will be nothing like this). There are some analysis challenges to overcome to determine what to display on this creen and how to link sentences to recalls. This PR is an attempt to make analysis easier, so that they can see the calc breakdown information as well as sentence and offence info easily.

also upgraded to the latest design system in preparation to use the latest sentence-and-offence card (but not used yet)

<img width="315" alt="Screenshot 2024-08-20 at 17 47 19" src="https://github.com/user-attachments/assets/98d858e7-90a6-4f5a-859a-45188632791c">



