### PR TITLE
RCLL-338 excludes current recall from validation

### DIFF
--- a/server/controllers/recall/returnToCustodyDateController.test.ts
+++ b/server/controllers/recall/returnToCustodyDateController.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { jest } from '@jest/globals'
 import ReturnToCustodyDateController from './returnToCustodyDateController'
 import { calculateUal } from '../../utils/utils'
 import getJourneyDataFromRequest, {
@@ -9,52 +8,22 @@ import getJourneyDataFromRequest, {
   getRevocationDate,
   getPrisoner,
   getExistingAdjustments,
+  getAdjustmentsToConsiderForValidation, // Import the function itself for mocking
 } from '../../helpers/formWizardHelper'
 
-jest.mock('../../helpers/formWizardHelper', () => ({
-  __esModule: true,
-  default: jest.fn(),
-  getPrisoner: jest.fn(),
-  getRevocationDate: jest.fn(),
-  getExistingAdjustments: jest.fn(),
-  sessionModelFields: {
-    ENTRYPOINT: 'entrypoint',
-    CRDS_ERRORS: 'crdsValidationErrors',
-    HAPPY_PATH_FAIL_REASONS: 'autoRecallFailErrors',
-    PRISONER: 'prisoner',
-    UAL: 'UAL',
-    RECALL_ID: 'recallId',
-    STORED_RECALL: 'storedRecall',
-    STANDARD_ONLY: 'standardOnlyRecall',
-    RECALL_TYPE: 'recallType',
-    MANUAL_CASE_SELECTION: 'manualCaseSelection',
-    COURT_CASE_OPTIONS: 'CourtCaseOptions',
-    COURT_CASES: 'courtCases',
-    IN_PRISON_AT_RECALL: 'inPrisonAtRecall',
-    RTC_DATE: 'returnToCustodyDate',
-    REVOCATION_DATE: 'revocationDate',
-    ELIGIBLE_SENTENCE_COUNT: 'eligibleSentenceCount',
-    SUMMARISED_SENTENCES: 'summarisedSentenceGroups',
-    IS_EDIT: 'isEdit',
-    RETURN_TO: 'returnTo',
-    JOURNEY_COMPLETE: 'journeyComplete',
-    SENTENCES: 'sentences',
-    TEMP_CALC: 'temporaryCalculation',
-    BREAKDOWN: 'breakdown',
-    GROUPED_SENTENCES: 'groupedSentences',
-    CASES_WITH_ELIGIBLE_SENTENCES: 'casesWithEligibleSentences',
-    RECALL_ELIGIBILITY: 'recallEligibility',
-    RECALL_TYPE_MISMATCH: 'recallTypeMismatch',
-    EXISTING_ADJUSTMENTS: 'existingAdjustments',
-    INVALID_RECALL_TYPES: 'invalidRecallTypes',
-    CONFLICTING_ADJUSTMENTS: 'conflictingAdjustments',
-    RELEVANT_ADJUSTMENT: 'relevantAdjustment',
-    UAL_TO_CREATE: 'ualToCreate',
-    UAL_TO_EDIT: 'ualToEdit',
-    INCOMPATIBLE_TYPES_AND_MULTIPLE_CONFLICTING_ADJUSTMENTS: 'incompatibleTypesAndMultipleConflictingAdjustments',
-    HAS_MULTIPLE_OVERLAPPING_UAL_TYPE_RECALL: 'hasMultipleOverlappingUalTypeRecall',
-  },
-}))
+jest.mock('../../helpers/formWizardHelper', () => {
+  const actualFormWizardHelper = jest.requireActual('../../helpers/formWizardHelper')
+  const mockGetJourneyDataFromRequest = jest.fn((...args: any[]) => actualFormWizardHelper.default(...args))
+
+  return {
+    ...actualFormWizardHelper,
+    __esModule: true,
+    default: mockGetJourneyDataFromRequest,
+    getPrisoner: jest.fn(),
+    getRevocationDate: jest.fn(),
+    getExistingAdjustments: jest.fn(),
+  }
+})
 
 jest.mock('../../utils/utils', () => ({
   calculateUal: jest.fn(),

--- a/server/controllers/recall/returnToCustodyDateController.test.ts
+++ b/server/controllers/recall/returnToCustodyDateController.test.ts
@@ -8,7 +8,6 @@ import getJourneyDataFromRequest, {
   getRevocationDate,
   getPrisoner,
   getExistingAdjustments,
-  getAdjustmentsToConsiderForValidation, // Import the function itself for mocking
 } from '../../helpers/formWizardHelper'
 
 jest.mock('../../helpers/formWizardHelper', () => {

--- a/server/controllers/recall/returnToCustodyDateController.test.ts
+++ b/server/controllers/recall/returnToCustodyDateController.test.ts
@@ -11,11 +11,11 @@ import getJourneyDataFromRequest, {
 } from '../../helpers/formWizardHelper'
 
 jest.mock('../../helpers/formWizardHelper', () => {
-  const actualFormWizardHelper = jest.requireActual('../../helpers/formWizardHelper')
-  const mockGetJourneyDataFromRequest = jest.fn((...args: any[]) => actualFormWizardHelper.default(...args))
+  const formWizardHelper = jest.requireActual('../../helpers/formWizardHelper')
+  const mockGetJourneyDataFromRequest = jest.fn((...args: any[]) => formWizardHelper.default(...args))
 
   return {
-    ...actualFormWizardHelper,
+    ...formWizardHelper,
     __esModule: true,
     default: mockGetJourneyDataFromRequest,
     getPrisoner: jest.fn(),

--- a/server/controllers/recall/returnToCustodyDateController.ts
+++ b/server/controllers/recall/returnToCustodyDateController.ts
@@ -2,7 +2,6 @@ import FormWizard from 'hmpo-form-wizard'
 import { NextFunction, Response } from 'express'
 import { isBefore, isAfter, isEqual } from 'date-fns'
 import _ from 'lodash'
-// eslint-disable-next-line import/no-unresolved
 import type { UAL } from 'models'
 import RecallBaseController from './recallBaseController'
 import { calculateUal } from '../../utils/utils'

--- a/server/controllers/recall/returnToCustodyDateController.ts
+++ b/server/controllers/recall/returnToCustodyDateController.ts
@@ -7,6 +7,7 @@ import type { UAL } from 'models'
 import RecallBaseController from './recallBaseController'
 import { calculateUal } from '../../utils/utils'
 import getJourneyDataFromRequest, {
+  getAdjustmentsToConsiderForValidation,
   getExistingAdjustments,
   getPrisoner,
   getRevocationDate,
@@ -146,19 +147,7 @@ export default class ReturnToCustodyDateController extends RecallBaseController 
 
     const allExistingAdjustments: AdjustmentDto[] = getExistingAdjustments(req)
 
-    const isEditRecall = journeyData.isEdit
-    const currentRecallId = journeyData.storedRecall?.recallId
-    const adjustmentsToConsider = allExistingAdjustments.filter((adjustment: AdjustmentDto) => {
-      if (
-        isEditRecall &&
-        currentRecallId &&
-        adjustment.recallId === currentRecallId &&
-        adjustment.adjustmentType === 'UNLAWFULLY_AT_LARGE'
-      ) {
-        return false // Ignore this adjustment
-      }
-      return true // Include all other adjustments
-    })
+    const adjustmentsToConsider = getAdjustmentsToConsiderForValidation(journeyData, allExistingAdjustments)
 
     const hasNoRecallUalConflicts = this.validateAgainstExistingRecallUalAdjustments(
       req,

--- a/server/controllers/recall/revocationDateController.test.ts
+++ b/server/controllers/recall/revocationDateController.test.ts
@@ -72,7 +72,6 @@ describe('RevocationDateController', () => {
           ? ({
               recallId: currentRecallIdVal,
               createdAt: '2023-01-01T00:00:00.000Z',
-              // Ensure all Recall fields are appropriately mocked or explicitly undefined if not used by the controller logic
               revocationDate: new Date('2023-01-01'),
               returnToCustodyDate: new Date('2023-01-10'),
               recallType: { code: 'LR', description: 'Standard', fixedTerm: false },
@@ -142,7 +141,6 @@ describe('RevocationDateController', () => {
     })
 
     it('should fail if revocation date is before earliest valid sentence date', done => {
-      // Renamed test
       const earliestSentenceTestSetupDate = new Date()
       earliestSentenceTestSetupDate.setDate(earliestSentenceTestSetupDate.getDate() + 2) // "Day after tomorrow"
       const earliestSentenceDateForTest = earliestSentenceTestSetupDate.toISOString().split('T')[0]

--- a/server/controllers/recall/revocationDateController.test.ts
+++ b/server/controllers/recall/revocationDateController.test.ts
@@ -1,0 +1,248 @@
+import { Response } from 'express'
+import FormWizard from 'hmpo-form-wizard'
+// eslint-disable-next-line import/no-unresolved
+import { Recall } from 'models'
+import RevocationDateController from './revocationDateController'
+import { AdjustmentDto } from '../../@types/adjustmentsApi/adjustmentsApiTypes'
+import getJourneyDataFromRequest, { RecallJourneyData } from '../../helpers/formWizardHelper'
+
+jest.mock('../../helpers/formWizardHelper', () => {
+  const actual = jest.requireActual('../../helpers/formWizardHelper')
+  return {
+    __esModule: true,
+    ...actual,
+    default: jest.fn(),
+    getExistingAdjustments: jest.fn(),
+    getCrdsSentences: jest.fn().mockReturnValue([]),
+  }
+})
+
+describe('RevocationDateController', () => {
+  let req: FormWizard.Request
+  let res: Response
+  const controller = new RevocationDateController({ fields: {}, route: '/mock-route' })
+
+  const recallId = 'RECALL_123'
+  const nomsId = 'A1234BC'
+
+  beforeEach(() => {
+    req = {
+      params: { nomsId },
+      session: {
+        token: 'token',
+        userDetails: { userId: 'user1' },
+      },
+      form: {
+        values: {},
+        errors: {},
+        options: { fields: {} },
+      },
+      flash: jest.fn(),
+      isEditing: false,
+      journeyModel: { get: jest.fn(), set: jest.fn(), load: jest.fn(), reset: jest.fn(), data: {} },
+      sessionModel: { get: jest.fn(), set: jest.fn(), reset: jest.fn(), data: {} },
+    } as unknown as FormWizard.Request
+
+    res = {
+      locals: {
+        user: { token: 'token', nomisId: nomsId },
+        urlInfo: { basePath: '/' },
+      },
+      render: jest.fn(),
+      redirect: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    } as unknown as Response
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('validateFields', () => {
+    const validRevocationDate = '2023-01-01'
+    const futureDate = new Date()
+    futureDate.setDate(futureDate.getDate() + 1)
+    const futureRevocationDate = futureDate.toISOString().split('T')[0]
+
+    const mockJourneyData = (isEdit: boolean, currentRecallIdVal?: string): RecallJourneyData => ({
+      isEdit,
+      storedRecall:
+        isEdit && currentRecallIdVal
+          ? ({
+              recallId: currentRecallIdVal,
+              createdAt: '2023-01-01T00:00:00.000Z',
+              // Ensure all Recall fields are appropriately mocked or explicitly undefined if not used by the controller logic
+              revocationDate: new Date('2023-01-01'),
+              returnToCustodyDate: new Date('2023-01-10'),
+              recallType: { code: 'LR', description: 'Standard', fixedTerm: false },
+              location: 'prison',
+              sentenceIds: [],
+              courtCaseIds: [],
+            } as Recall)
+          : undefined,
+      revocationDate: undefined,
+      revDateString: '',
+      inPrisonAtRecall: false,
+      returnToCustodyDate: undefined,
+      returnToCustodyDateString: '',
+      ual: undefined,
+      ualText: '',
+      manualCaseSelection: false,
+      recallType: { code: 'LR', description: 'Standard', fixedTerm: false },
+      courtCaseCount: 0,
+      eligibleSentenceCount: 0,
+      sentenceIds: [],
+    })
+
+    const ualAdjustmentLinked: AdjustmentDto = {
+      id: 'ual-linked-1',
+      bookingId: 123,
+      sentenceSequence: 1,
+      adjustmentType: 'UNLAWFULLY_AT_LARGE',
+      fromDate: '2022-12-20',
+      toDate: '2023-01-05',
+      days: 17,
+      recallId,
+      person: nomsId,
+    }
+
+    const ualAdjustmentUnlinked: AdjustmentDto = {
+      id: 'ual-unlinked-1',
+      bookingId: 123,
+      sentenceSequence: 1,
+      adjustmentType: 'UNLAWFULLY_AT_LARGE',
+      fromDate: '2022-12-20',
+      toDate: '2023-01-05',
+      days: 17,
+      recallId: 'OTHER_RECALL_456',
+      person: nomsId,
+    }
+
+    const ualAdjustmentNoRecallId: AdjustmentDto = {
+      id: 'ual-no-recall-1',
+      bookingId: 123,
+      sentenceSequence: 1,
+      adjustmentType: 'UNLAWFULLY_AT_LARGE',
+      fromDate: '2022-12-20',
+      toDate: '2023-01-05',
+      days: 17,
+      person: nomsId,
+    }
+
+    it('should pass validation with a valid date and no conflicting adjustments', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = validRevocationDate
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(false, undefined))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([])
+
+      controller.validateFields(req, res, errors => {
+        expect(Object.keys(errors).length).toBe(0)
+        done()
+      })
+    })
+
+    it('should fail if revocation date is before earliest valid sentence date', done => {
+      // Renamed test
+      const earliestSentenceTestSetupDate = new Date()
+      earliestSentenceTestSetupDate.setDate(earliestSentenceTestSetupDate.getDate() + 2) // "Day after tomorrow"
+      const earliestSentenceDateForTest = earliestSentenceTestSetupDate.toISOString().split('T')[0]
+
+      // Set revocationDate to "tomorrow" (futureRevocationDate), which is before "day after tomorrow" (earliestSentenceDateForTest)
+      ;(req.form.values as { revocationDate: string }).revocationDate = futureRevocationDate
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(false, undefined))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([])
+      // Temporarily override the global mock for getCrdsSentences for this specific test case
+      ;(jest.requireMock('../../helpers/formWizardHelper').getCrdsSentences as jest.Mock).mockReturnValueOnce([
+        {
+          sentenceDate: earliestSentenceDateForTest,
+          bookingId: 123,
+          sentenceSequence: 1,
+          lineSequence: 1,
+          caseSequence: 1,
+          recallType: 'STANDARD',
+          releaseDate: earliestSentenceDateForTest,
+        },
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect((errors as Record<string, FormWizard.Controller.Error>).revocationDate.type).toBe(
+          'mustBeAfterEarliestSentenceDate',
+        )
+        done()
+      })
+    })
+
+    it('Edit Mode - should pass if overlapping UAL is linked to the current recall', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = '2023-01-01'
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(true, recallId))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([
+        ualAdjustmentLinked,
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect(Object.keys(errors).length).toBe(0)
+        done()
+      })
+    })
+
+    it('Edit Mode - should fail if overlapping UAL is linked to a different recall', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = '2023-01-01'
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(true, recallId))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([
+        ualAdjustmentUnlinked,
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect((errors as Record<string, FormWizard.Controller.Error>).revocationDate.type).toBe(
+          'cannotBeWithinAdjustmentPeriod',
+        )
+        done()
+      })
+    })
+
+    it('Edit Mode - should fail if overlapping UAL has no recallId', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = '2023-01-01'
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(true, recallId))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([
+        ualAdjustmentNoRecallId,
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect((errors as Record<string, FormWizard.Controller.Error>).revocationDate.type).toBe(
+          'cannotBeWithinAdjustmentPeriod',
+        )
+        done()
+      })
+    })
+
+    it('Create Mode - should fail if overlapping UAL exists (linked to different recall)', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = '2023-01-01'
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(false, undefined))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([
+        ualAdjustmentUnlinked,
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect((errors as Record<string, FormWizard.Controller.Error>).revocationDate.type).toBe(
+          'cannotBeWithinAdjustmentPeriod',
+        )
+        done()
+      })
+    })
+
+    it('Create Mode - should fail if overlapping UAL exists (no recallId)', done => {
+      ;(req.form.values as { revocationDate: string }).revocationDate = '2023-01-01'
+      ;(getJourneyDataFromRequest as jest.Mock).mockReturnValue(mockJourneyData(false, undefined))
+      ;(jest.requireMock('../../helpers/formWizardHelper').getExistingAdjustments as jest.Mock).mockReturnValue([
+        ualAdjustmentNoRecallId,
+      ])
+
+      controller.validateFields(req, res, errors => {
+        expect((errors as Record<string, FormWizard.Controller.Error>).revocationDate.type).toBe(
+          'cannotBeWithinAdjustmentPeriod',
+        )
+        done()
+      })
+    })
+  })
+})

--- a/server/controllers/recall/revocationDateController.ts
+++ b/server/controllers/recall/revocationDateController.ts
@@ -6,9 +6,11 @@ import RecallBaseController from './recallBaseController'
 import { PrisonerSearchApiPrisoner } from '../../@types/prisonerSearchApi/prisonerSearchTypes'
 import revocationDateCrdsDataComparison from '../../utils/revocationDateCrdsDataComparison'
 import getJourneyDataFromRequest, {
+  getAdjustmentsToConsiderForValidation,
   getCrdsSentences,
   getExistingAdjustments,
   getRecallRoute,
+  RecallJourneyData,
 } from '../../helpers/formWizardHelper'
 import { AdjustmentDto } from '../../@types/adjustmentsApi/adjustmentsApiTypes'
 
@@ -33,23 +35,9 @@ export default class RevocationDateController extends RecallBaseController {
         validationErrors.revocationDate = this.formError('revocationDate', 'mustBeAfterEarliestSentenceDate')
       }
 
-      const journeyData = getJourneyDataFromRequest(req)
-      const isEditRecall = journeyData.isEdit
-      const currentRecallId = journeyData.storedRecall?.recallId
-
+      const journeyData: RecallJourneyData = getJourneyDataFromRequest(req)
       const allExistingAdjustments: AdjustmentDto[] = getExistingAdjustments(req)
-
-      const adjustmentsToConsider = allExistingAdjustments.filter((adjustment: AdjustmentDto) => {
-        if (
-          isEditRecall &&
-          currentRecallId &&
-          adjustment.recallId === currentRecallId &&
-          adjustment.adjustmentType === 'UNLAWFULLY_AT_LARGE'
-        ) {
-          return false // Ignore this adjustment
-        }
-        return true // Include all other adjustments
-      })
+      const adjustmentsToConsider = getAdjustmentsToConsiderForValidation(journeyData, allExistingAdjustments)
 
       const revocationDate = new Date(values.revocationDate as string)
 

--- a/server/helpers/formWizardHelper.ts
+++ b/server/helpers/formWizardHelper.ts
@@ -176,6 +176,30 @@ export function getExistingAdjustments(req: FormWizard.Request): AdjustmentDto[]
   return get<AdjustmentDto[]>(req, sessionModelFields.EXISTING_ADJUSTMENTS)
 }
 
+export function getAdjustmentsToConsiderForValidation(
+  journeyData: RecallJourneyData,
+  allExistingAdjustments: AdjustmentDto[],
+): AdjustmentDto[] {
+  const { isEdit, storedRecall } = journeyData
+  const currentRecallId = storedRecall?.recallId
+
+  if (!allExistingAdjustments) {
+    return []
+  }
+
+  return allExistingAdjustments.filter((adjustment: AdjustmentDto) => {
+    if (
+      isEdit &&
+      currentRecallId &&
+      adjustment.recallId === currentRecallId &&
+      adjustment.adjustmentType === 'UNLAWFULLY_AT_LARGE'
+    ) {
+      return false // Ignore UAL linked to the current recall being edited
+    }
+    return true // Include all other adjustments
+  })
+}
+
 export function getDpsSentenceId(req: FormWizard.Request): DpsSentenceIds {
   return get<DpsSentenceIds>(req, sessionModelFields.DPS_SENTENCE_IDS)
 }


### PR DESCRIPTION
This branch adds an additional condition to the existing set of UAL checks/validations when editing a recall that has an associated period of UAL. In this scenario, this additional condition should ignore the existing period of associated UAL when checking for existing/overlapping UAL, to ensure that the user does not hit any validation errors in relation to this UAL period. 