### PR TITLE
RCLL-369 - Implements UAL cleanup for deleted recalls

### DIFF
--- a/server/api/AdjustmentsApiClient.test.ts
+++ b/server/api/AdjustmentsApiClient.test.ts
@@ -1,0 +1,45 @@
+import AdjustmentsApiClient from './adjustmentsApiClient'
+import RestClient from '../data/restClient'
+
+describe('AdjustmentsApiClient', () => {
+  let adjustmentsApiClient: AdjustmentsApiClient
+  const mockToken = 'test-token'
+  let restClientDeleteMock: jest.SpyInstance
+
+  beforeEach(() => {
+    restClientDeleteMock = jest.spyOn(RestClient.prototype, 'delete')
+    adjustmentsApiClient = new AdjustmentsApiClient(mockToken)
+  })
+
+  afterEach(() => {
+    restClientDeleteMock.mockRestore()
+  })
+
+  describe('deleteAdjustment', () => {
+    it('should call restClient.delete with the correct path', async () => {
+      const adjustmentId = 'some-uuid'
+      restClientDeleteMock.mockResolvedValue(undefined)
+
+      await adjustmentsApiClient.deleteAdjustment(adjustmentId)
+
+      expect(restClientDeleteMock).toHaveBeenCalledWith({
+        path: `/adjustments/${adjustmentId}`,
+      })
+    })
+
+    it('should resolve when delete is successful', async () => {
+      const adjustmentId = 'some-uuid'
+      restClientDeleteMock.mockResolvedValue(undefined)
+
+      await expect(adjustmentsApiClient.deleteAdjustment(adjustmentId)).resolves.toBeUndefined()
+    })
+
+    it('should reject if restClient.delete throws an error', async () => {
+      const adjustmentId = 'some-uuid'
+      const error = new Error('API Error')
+      restClientDeleteMock.mockRejectedValue(error)
+
+      await expect(adjustmentsApiClient.deleteAdjustment(adjustmentId)).rejects.toThrow(error)
+    })
+  })
+})

--- a/server/api/adjustmentsApiClient.ts
+++ b/server/api/adjustmentsApiClient.ts
@@ -23,12 +23,19 @@ export default class AdjustmentsApiClient {
     }) as Promise<CreateResponse>
   }
 
-  async getAdjustments(person: string): Promise<AdjustmentDto[]> {
+  async getAdjustments(person: string, recallUuid?: string): Promise<AdjustmentDto[]> {
     return this.restClient.get({
       query: {
         person,
+        recallId: recallUuid,
       },
       path: `/adjustments`,
     }) as Promise<AdjustmentDto[]>
+  }
+
+  async deleteAdjustment(adjustmentId: string): Promise<void> {
+    await this.restClient.delete({
+      path: `/adjustments/${adjustmentId}`,
+    })
   }
 }

--- a/server/controllers/recall/deleteRecallController.test.ts
+++ b/server/controllers/recall/deleteRecallController.test.ts
@@ -174,7 +174,7 @@ describe('deleteRecallController', () => {
 
       await postDeleteRecallConfirmation(req as unknown as Request, res as Response)
 
-      expect(mockRecallService.deleteRecall).toHaveBeenCalledWith(recallId, user.username)
+      expect(mockRecallService.deleteRecall).toHaveBeenCalledWith(nomisId, recallId, user.username)
       expect(req.flash).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith(`/person/${nomisId}`)
     })

--- a/server/controllers/recall/deleteRecallController.ts
+++ b/server/controllers/recall/deleteRecallController.ts
@@ -51,7 +51,7 @@ export async function postDeleteRecallConfirmation(req: Request, res: Response) 
   }
 
   if (confirmDelete === 'yes') {
-    await req.services.recallService.deleteRecall(recallId, req.user?.username)
+    await req.services.recallService.deleteRecall(nomisId, recallId, req.user?.username)
     return res.redirect(redirectUrl)
   }
 

--- a/server/services/adjustmentsService.ts
+++ b/server/services/adjustmentsService.ts
@@ -38,8 +38,12 @@ export default class AdjustmentsService {
     return (await this.getApiClient(username)).updateAdjustment(adjustmentId, adjustmentToUpdate)
   }
 
-  async searchUal(nomisId: string, username: string): Promise<AdjustmentDto[]> {
-    return (await this.getApiClient(username)).getAdjustments(nomisId)
+  async searchUal(nomisId: string, username: string, recallUuid?: string): Promise<AdjustmentDto[]> {
+    return (await this.getApiClient(username)).getAdjustments(nomisId, recallUuid)
+  }
+
+  async deleteAdjustment(adjustmentId: string, username: string): Promise<void> {
+    return (await this.getApiClient(username)).deleteAdjustment(adjustmentId)
   }
 
   private async getApiClient(username: string): Promise<AdjustmentsApiClient> {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -18,7 +18,8 @@ export const services = () => {
 
   const auditService = new AuditService(hmppsAuditClient)
   const prisonerService = new PrisonerService(hmppsAuthClient)
-  const recallService = new RecallService(hmppsAuthClient)
+  const adjustmentsService = new AdjustmentsService(hmppsAuthClient)
+  const recallService = new RecallService(hmppsAuthClient, adjustmentsService)
   const calculationService = new CalculationService(hmppsAuthClient)
   const feComponentsService = new FeComponentsService(feComponentsClient)
   const bulkCalculationService = new BulkCalculationService(calculationService)
@@ -26,7 +27,6 @@ export const services = () => {
   const courtCaseService = new CourtCaseService(hmppsAuthClient)
   const courtService = new CourtService(hmppsAuthClient)
   const prisonService = new PrisonService(hmppsAuthClient)
-  const adjustmentsService = new AdjustmentsService(hmppsAuthClient)
   const manageUsersService = new ManageUsersService(manageUsersApiClient)
   const nomisMappingService = new NomisToDpsMappingService(hmppsAuthClient)
 

--- a/server/services/recallService.test.ts
+++ b/server/services/recallService.test.ts
@@ -7,21 +7,25 @@ import {
   CreateRecall,
   CreateRecallResponse,
 } from '../@types/remandAndSentencingApi/remandAndSentencingTypes'
-
 import { RecallTypes } from '../@types/recallTypes'
+import logger from '../../logger'
 import { formatDate } from '../utils/utils'
+import AdjustmentsService from './adjustmentsService'
 
 jest.mock('../data/hmppsAuthClient')
+jest.mock('./adjustmentsService')
 
 describe('Recall service', () => {
   let fakeRemandAndSentencingApi: nock.Scope
   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
+  let adjustmentsService: jest.Mocked<AdjustmentsService>
   let recallService: RecallService
 
   beforeEach(() => {
     fakeRemandAndSentencingApi = nock(config.apis.remandAndSentencingApi.url)
     hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-    recallService = new RecallService(hmppsAuthClient)
+    adjustmentsService = new AdjustmentsService(null) as jest.Mocked<AdjustmentsService>
+    recallService = new RecallService(hmppsAuthClient, adjustmentsService)
   })
 
   describe('createRecall', () => {
@@ -92,6 +96,121 @@ describe('Recall service', () => {
           courtCaseIds: ['CASE1'],
         },
       ])
+    })
+  })
+
+  describe('deleteRecall', () => {
+    const nomisId = 'A1234BC'
+    const recallId = 'recall-uuid-123'
+    const username = 'userTest1'
+
+    let loggerErrorSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      adjustmentsService.searchUal = jest.fn()
+      adjustmentsService.deleteAdjustment = jest.fn()
+      loggerErrorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      loggerErrorSpy.mockRestore()
+    })
+
+    it('should delete recall and not attempt to delete UALs if none are found', async () => {
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).reply(200)
+      adjustmentsService.searchUal = jest.fn().mockResolvedValue([])
+      adjustmentsService.deleteAdjustment = jest.fn()
+
+      await recallService.deleteRecall(nomisId, recallId, username)
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).toHaveBeenCalledWith(nomisId, username, recallId)
+      expect(adjustmentsService.deleteAdjustment).not.toHaveBeenCalled()
+    })
+
+    it('should delete recall, find one UAL, and delete it successfully', async () => {
+      const ualAdjustment = { id: 'ual-uuid-1', person: nomisId, recallId }
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).reply(200)
+      adjustmentsService.searchUal = jest.fn().mockResolvedValue([ualAdjustment])
+      adjustmentsService.deleteAdjustment = jest.fn().mockResolvedValue(undefined)
+
+      await recallService.deleteRecall(nomisId, recallId, username)
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).toHaveBeenCalledWith(nomisId, username, recallId)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledWith(ualAdjustment.id, username)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledTimes(1)
+    })
+
+    it('should delete recall, find multiple UALs, and delete them all successfully', async () => {
+      const ualAdjustments = [
+        { id: 'ual-uuid-1', person: nomisId, recallId },
+        { id: 'ual-uuid-2', person: nomisId, recallId },
+      ]
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).reply(200)
+      adjustmentsService.searchUal = jest.fn().mockResolvedValue(ualAdjustments)
+      adjustmentsService.deleteAdjustment = jest.fn().mockResolvedValue(undefined)
+
+      await recallService.deleteRecall(nomisId, recallId, username)
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).toHaveBeenCalledWith(nomisId, username, recallId)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledWith(ualAdjustments[0].id, username)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledWith(ualAdjustments[1].id, username)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledTimes(2)
+    })
+
+    it('should delete recall and not attempt UAL deletion if UAL search fails', async () => {
+      const searchError = new Error('UAL Search Failed')
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).reply(200)
+      adjustmentsService.searchUal = jest.fn().mockRejectedValue(searchError)
+      adjustmentsService.deleteAdjustment = jest.fn()
+
+      await expect(recallService.deleteRecall(nomisId, recallId, username)).resolves.toBeUndefined()
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).toHaveBeenCalledWith(nomisId, username, recallId)
+      expect(adjustmentsService.deleteAdjustment).not.toHaveBeenCalled()
+      expect(loggerErrorSpy).toHaveBeenCalledWith(searchError)
+    })
+
+    it('should delete recall, attempt all UAL deletions even if one fails, and log errors', async () => {
+      const ualAdjustments = [
+        { id: 'ual-uuid-1', person: nomisId, recallId },
+        { id: 'ual-uuid-2', person: nomisId, recallId },
+      ]
+      const deleteError = new Error('UAL Deletion Failed for ual-uuid-1')
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).reply(200)
+      adjustmentsService.searchUal = jest.fn().mockResolvedValue(ualAdjustments)
+      adjustmentsService.deleteAdjustment = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(deleteError))
+        .mockImplementationOnce(() => Promise.resolve(undefined))
+
+      await expect(recallService.deleteRecall(nomisId, recallId, username)).resolves.toBeUndefined()
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).toHaveBeenCalledWith(nomisId, username, recallId)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledWith(ualAdjustments[0].id, username)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledWith(ualAdjustments[1].id, username)
+      expect(adjustmentsService.deleteAdjustment).toHaveBeenCalledTimes(2)
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        `Failed to delete UAL adjustment ${ualAdjustments[0].id} for recall ${recallId} (person ${nomisId}):`,
+        deleteError,
+      )
+    })
+
+    it('should reject and not attempt UAL operations if initial recall deletion fails', async () => {
+      const recallDeleteError = new Error('Recall Deletion Failed')
+      fakeRemandAndSentencingApi.delete(`/recall/${recallId}`).replyWithError(recallDeleteError)
+      adjustmentsService.searchUal = jest.fn()
+      adjustmentsService.deleteAdjustment = jest.fn()
+
+      await expect(recallService.deleteRecall(nomisId, recallId, username)).rejects.toThrow(recallDeleteError)
+
+      expect(fakeRemandAndSentencingApi.isDone()).toBe(true)
+      expect(adjustmentsService.searchUal).not.toHaveBeenCalled()
+      expect(adjustmentsService.deleteAdjustment).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
When a recall is deleted, associated UAL adjustments are also deleted to maintain data integrity. UAL adjustments deletion is performed after successful recall deletion, with error handling and logging to ensure all UALs are removed if possible.