### PR TITLE
Rcll 243 offence card in eligible sentences page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.799.0",
         "@ministryofjustice/frontend": "^4.0.2",
+        "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.5.0",
         "@types/cookie-parser": "^1.4.8",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^3.7.0",
@@ -2557,6 +2558,25 @@
         "govuk-frontend": "5.x",
         "jquery": "3.x",
         "moment": "2.x"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-4.5.0.tgz",
+      "integrity": "sha512-WlH6EEauyOLFPMl7elj8o/xyUHFJyTglKK0sIbo/Yf4mfPmu5kV5w4VefHRebJXdP69v7t9kTxa5UWunnwRgxA==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^3.2.0"
+      }
+    },
+    "node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@mswjs/interceptors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "govuk-frontend": "^5.10.0",
         "helmet": "^8.1.0",
         "hmpo-form-wizard": "^15.0.0",
-        "hmpps-court-cases-release-dates-design": "^4.4.0",
         "http-errors": "^2.0.0",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
@@ -9814,25 +9813,6 @@
       },
       "engines": {
         "node": "20.x || 22.x"
-      }
-    },
-    "node_modules/hmpps-court-cases-release-dates-design": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-4.4.0.tgz",
-      "integrity": "sha512-grdiNs23jzyIAjIhYaJTCDnNAPcDWK2J3ibMItA4lXCniPzzN30dB0K70+8O3stEwAFNcN4QjCJ73s9eT14YXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "date-fns": "^3.2.0"
-      }
-    },
-    "node_modules/hmpps-court-cases-release-dates-design/node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/html-escaper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.799.0",
         "@ministryofjustice/frontend": "^4.0.2",
-        "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.5.0",
+        "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.6.0",
         "@types/cookie-parser": "^1.4.8",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^3.7.0",
@@ -2561,9 +2561,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-4.5.0.tgz",
-      "integrity": "sha512-WlH6EEauyOLFPMl7elj8o/xyUHFJyTglKK0sIbo/Yf4mfPmu5kV5w4VefHRebJXdP69v7t9kTxa5UWunnwRgxA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-court-cases-release-dates-design/-/hmpps-court-cases-release-dates-design-4.6.0.tgz",
+      "integrity": "sha512-yltfkfylZxc7RhXBmELJDjyIwR9dTEpWwEN7rux25cH2Ocx3l/u1fwmfAjEU4CJa0RAIvlNiCYtRyQ0pFWeo0g==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.799.0",
     "@ministryofjustice/frontend": "^4.0.2",
-    "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.5.0",
+    "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.6.0",
     "@types/cookie-parser": "^1.4.8",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky",
     "copy-views": "cp -R server/views dist/server/",
-    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=node_modules/hmpps-court-cases-release-dates-design --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
+    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend/dist --load-path=node_modules/@ministryofjustice/frontend --load-path=node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
     "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",
@@ -123,7 +123,6 @@
     "govuk-frontend": "^5.10.0",
     "helmet": "^8.1.0",
     "hmpo-form-wizard": "^15.0.0",
-    "hmpps-court-cases-release-dates-design": "^4.4.0",
     "http-errors": "^2.0.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.799.0",
     "@ministryofjustice/frontend": "^4.0.2",
+    "@ministryofjustice/hmpps-court-cases-release-dates-design": "^4.5.0",
     "@types/cookie-parser": "^1.4.8",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^3.7.0",

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -21,8 +21,8 @@ export default function setUpStaticResources(): Router {
     '/node_modules/govuk-frontend/dist',
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
-    '/node_modules/hmpps-court-cases-release-dates-design/hmpps/assets',
-    '/node_modules/hmpps-court-cases-release-dates-design',
+    '/node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design/hmpps/assets',
+    '/node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,6 +9,7 @@ import {
   personStatus,
   firstNameSpaceLastName,
   formatLengths,
+  // consecutiveToDetailsToDescription,
 } from 'hmpps-court-cases-release-dates-design/hmpps/utils/utils'
 import dayjs from 'dayjs'
 import { initialiseName } from './utils'
@@ -77,6 +78,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('datetime', (date, format = 'YYYY-MM-DD HH:mm:ss') => dayjs(date).format(format))
   njkEnv.addFilter('sentenceDate', (date, format = 'dddd, DD MMMM YYYY') => dayjs(date).format(format))
   njkEnv.addFilter('formatLengths', formatLengths)
+  // njkEnv.addFilter('consecutiveToDetailsToDescription', consecutiveToDetailsToDescription)
 
   // Filter to pluralize a word based on a count. Adds 's' if count is not 1.
   function pluralize(count: number): string {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,8 +9,8 @@ import {
   personStatus,
   firstNameSpaceLastName,
   formatLengths,
-  // consecutiveToDetailsToDescription,
-} from 'hmpps-court-cases-release-dates-design/hmpps/utils/utils'
+  consecutiveToDetailsToDescription,
+} from '@ministryofjustice/hmpps-court-cases-release-dates-design/hmpps/utils/utils'
 import dayjs from 'dayjs'
 import { initialiseName } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
@@ -44,8 +44,8 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
       path.join(__dirname, '../../server/views'),
       'node_modules/govuk-frontend/dist/',
       'node_modules/@ministryofjustice/frontend/',
-      'node_modules/hmpps-court-cases-release-dates-design/',
-      'node_modules/hmpps-court-cases-release-dates-design/hmpps/components/',
+      'node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design/',
+      'node_modules/@ministryofjustice/hmpps-court-cases-release-dates-design/hmpps/components/',
     ],
     {
       autoescape: true,
@@ -78,7 +78,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   njkEnv.addFilter('datetime', (date, format = 'YYYY-MM-DD HH:mm:ss') => dayjs(date).format(format))
   njkEnv.addFilter('sentenceDate', (date, format = 'dddd, DD MMMM YYYY') => dayjs(date).format(format))
   njkEnv.addFilter('formatLengths', formatLengths)
-  // njkEnv.addFilter('consecutiveToDetailsToDescription', consecutiveToDetailsToDescription)
+  njkEnv.addFilter('consecutiveToDetailsToDescription', consecutiveToDetailsToDescription)
 
   // Filter to pluralize a word based on a count. Adds 's' if count is not 1.
   function pluralize(count: number): string {

--- a/server/views/pages/recall/check-sentences.njk
+++ b/server/views/pages/recall/check-sentences.njk
@@ -141,27 +141,13 @@
 {% endmacro %}
 
 {% macro sentenceCard(sentence) %}
-    {# <div class="offence-card sentence-card">
-        <div class="govuk-width-container">
-            <div class="offence-card-offence-details">
-                <h4 class="govuk-heading-s">{{ sentence.offenceCode }} - {{ sentence.offenceDescription }}</h4>
-
-                {{ govukSummaryList({
-                    rows: sentence.summary,
-                    classes: "govuk-summary-list--no-border"
-                }) }}
-
-
-            </div>
-        </div>
-    </div> #}
         {{ offenceCard({
             offenceCode: 'OFFENCECODE',
             offenceName: 'An Offence Name',
             offenceStartDate: '27 06 2024',
             offenceEndDate: '27 08 2024',
             outcome: 'Imprisonment',
-            outcomeUpdated: true,
+            outcomeUpdated: false,
             hideOutcome: true,
             countNumber: '1',
             convictionDate: '12 09 2024',
@@ -180,15 +166,7 @@
             sentenceServeType: 'CONSECUTIVE',
             consecutiveTo: '3',
             sentenceType: 'SDS (Standard Determinate Sentence)',
-            detailsClasses: 'govuk-!-padding-4',
-            listItems: {
-                classes: 'govuk-!-margin-top-4',
-                items: [
-                    {
-                        html: '<a href="/update-outcome">Update outcome</a>'
-                    }
-                ]
-            }
+            detailsClasses: 'govuk-!-padding-4'
         }) }}
 
 {% endmacro %}

--- a/server/views/pages/recall/check-sentences.njk
+++ b/server/views/pages/recall/check-sentences.njk
@@ -162,15 +162,25 @@
             offenceEndDate: '27 08 2024',
             outcome: 'Imprisonment',
             outcomeUpdated: true,
+            hideOutcome: true,
             countNumber: '1',
             convictionDate: '12 09 2024',
             terrorRelated: false,
             isSentenced: true,
+            periodLengths: [
+              {
+                description: 'Sentence length',
+                years: '1',
+                months: '2',
+                weeks: '3',
+                days: '4',
+                periodOrder: ['years', 'months', 'weeks', 'days']
+                }
+            ],
             sentenceServeType: 'CONSECUTIVE',
             consecutiveTo: '3',
             sentenceType: 'SDS (Standard Determinate Sentence)',
             detailsClasses: 'govuk-!-padding-4',
-            hideOutcome: true,
             listItems: {
                 classes: 'govuk-!-margin-top-4',
                 items: [

--- a/server/views/pages/recall/check-sentences.njk
+++ b/server/views/pages/recall/check-sentences.njk
@@ -8,6 +8,8 @@
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "hmpps/components/court-cases-release-dates/offence-card/macro.njk" import offenceCard %}
+
 
 {% set errors = validationErrors[0].text %}
 
@@ -139,7 +141,7 @@
 {% endmacro %}
 
 {% macro sentenceCard(sentence) %}
-    <div class="offence-card sentence-card">
+    {# <div class="offence-card sentence-card">
         <div class="govuk-width-container">
             <div class="offence-card-offence-details">
                 <h4 class="govuk-heading-s">{{ sentence.offenceCode }} - {{ sentence.offenceDescription }}</h4>
@@ -152,6 +154,60 @@
 
             </div>
         </div>
-    </div>
+    </div> #}
+                
+                {{ offenceCard({
+                    offenceCode: 'OFFENCECODE',
+                    offenceName: 'An Offence Name',
+                    offenceStartDate: '27 06 2024',
+                    offenceEndDate: '27 08 2024',
+                    outcome: 'Imprisonment',
+                    outcomeUpdated: true,
+                    countNumber: '1',
+                    convictionDate: '12 09 2024',
+                    terrorRelated: true,
+                    isSentenced: true,
+                    periodLengths: [
+                        {
+                            description: 'Sentence length',
+                            years: '1',
+                            months: '2',
+                            weeks: '3',
+                            days: '4',
+                            periodOrder: ['years', 'months', 'weeks', 'days']
+                        },
+                        {
+                            description: 'Licence period',
+                            years: '5',
+                            months: '6',
+                            periodOrder: ['years', 'months']
+                        }
+                    ],
+                    sentenceServeType: 'CONSECUTIVE',
+                    consecutiveTo: '3',
+                    sentenceType: 'SDS (Standard Determinate Sentence)',
+                    fineAmount: '17000',
+                    detailsClasses: 'govuk-!-padding-4',
+                    actions: {
+                        items: [
+                        {
+                            text: 'Edit',
+                            href: '/edit'
+                        },
+                        {
+                            text: 'Delete',
+                            href: '/delete'
+                        }
+                        ]
+                    },
+                    listItems: {
+                        classes: 'govuk-!-margin-top-4',
+                        items: [
+                            {
+                                html: '<a href="/update-outcome">Update outcome</a>'
+                            }
+                        ]
+                    }
+                }) }}
 {% endmacro %}
 

--- a/server/views/pages/recall/check-sentences.njk
+++ b/server/views/pages/recall/check-sentences.njk
@@ -155,59 +155,31 @@
             </div>
         </div>
     </div> #}
-                
-                {{ offenceCard({
-                    offenceCode: 'OFFENCECODE',
-                    offenceName: 'An Offence Name',
-                    offenceStartDate: '27 06 2024',
-                    offenceEndDate: '27 08 2024',
-                    outcome: 'Imprisonment',
-                    outcomeUpdated: true,
-                    countNumber: '1',
-                    convictionDate: '12 09 2024',
-                    terrorRelated: true,
-                    isSentenced: true,
-                    periodLengths: [
-                        {
-                            description: 'Sentence length',
-                            years: '1',
-                            months: '2',
-                            weeks: '3',
-                            days: '4',
-                            periodOrder: ['years', 'months', 'weeks', 'days']
-                        },
-                        {
-                            description: 'Licence period',
-                            years: '5',
-                            months: '6',
-                            periodOrder: ['years', 'months']
-                        }
-                    ],
-                    sentenceServeType: 'CONSECUTIVE',
-                    consecutiveTo: '3',
-                    sentenceType: 'SDS (Standard Determinate Sentence)',
-                    fineAmount: '17000',
-                    detailsClasses: 'govuk-!-padding-4',
-                    actions: {
-                        items: [
-                        {
-                            text: 'Edit',
-                            href: '/edit'
-                        },
-                        {
-                            text: 'Delete',
-                            href: '/delete'
-                        }
-                        ]
-                    },
-                    listItems: {
-                        classes: 'govuk-!-margin-top-4',
-                        items: [
-                            {
-                                html: '<a href="/update-outcome">Update outcome</a>'
-                            }
-                        ]
+        {{ offenceCard({
+            offenceCode: 'OFFENCECODE',
+            offenceName: 'An Offence Name',
+            offenceStartDate: '27 06 2024',
+            offenceEndDate: '27 08 2024',
+            outcome: 'Imprisonment',
+            outcomeUpdated: true,
+            countNumber: '1',
+            convictionDate: '12 09 2024',
+            terrorRelated: false,
+            isSentenced: true,
+            sentenceServeType: 'CONSECUTIVE',
+            consecutiveTo: '3',
+            sentenceType: 'SDS (Standard Determinate Sentence)',
+            detailsClasses: 'govuk-!-padding-4',
+            hideOutcome: true,
+            listItems: {
+                classes: 'govuk-!-margin-top-4',
+                items: [
+                    {
+                        html: '<a href="/update-outcome">Update outcome</a>'
                     }
-                }) }}
+                ]
+            }
+        }) }}
+
 {% endmacro %}
 

--- a/server/views/partials/prisonerBannerLayout.njk
+++ b/server/views/partials/prisonerBannerLayout.njk
@@ -1,6 +1,8 @@
 {% extends "./layout.njk" %}
 {% from "hmpps/components/mini-profile/macro.njk" import miniProfile %}
 {% from "hmpps/components/court-cases-release-dates/sub-navigation/macro.njk" import subNavigation %}
+
+
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}


### PR DESCRIPTION
New offence card with only obligatory parameters showing on `eligible sentences` page

Note: screenshot only using hardcoded data as still need to get RAS sentences 


<img width="609" alt="Screenshot 2025-05-28 at 12 41 45" src="https://github.com/user-attachments/assets/21f2f4c0-d54a-4ac3-a25f-a9573681fc3c" />
