### PR TITLE
Investigate bug offence titles not showing in homepage

### DIFF
--- a/server/controllers/person/viewPersonHomeController.ts
+++ b/server/controllers/person/viewPersonHomeController.ts
@@ -5,7 +5,7 @@ import getServiceUrls from '../../helpers/urlHelper'
  * ViewPersonHomeController - Displays the person home page with recall information
  */
 export default async (req: Request, res: Response) => {
-  const { nomisId, prisoner, recalls, serviceDefinitions, banner, errorMessage } = res.locals
+  const { nomisId, prisoner, recalls, serviceDefinitions, banner, errorMessage, recallableCourtCases } = res.locals
 
   if (prisoner) {
     const urls = getServiceUrls(nomisId)
@@ -19,6 +19,7 @@ export default async (req: Request, res: Response) => {
       serviceDefinitions,
       errorMessage,
       latestRecallId: res.locals.latestRecallId,
+      recallableCourtCases
     })
   }
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -43,7 +43,7 @@ export default function routes(services: Services): Router {
     populateNomisId(),
     populateRecallId(),
     loadCourtCases(services.courtCaseService, services.manageOffencesService, services.courtService),
-    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService),
+    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService, services.courtService),
     editRecallRouter,
   )
   router.use(
@@ -51,7 +51,7 @@ export default function routes(services: Services): Router {
     populateEntrypoint(),
     populateNomisId(),
     loadCourtCases(services.courtCaseService, services.manageOffencesService, services.courtService),
-    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService),
+    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService, services.courtService),
     newRecallRouter,
   )
   router.use('/bulk', bulkTestRouter(services))

--- a/server/routes/viewPersonRouter.ts
+++ b/server/routes/viewPersonRouter.ts
@@ -18,7 +18,7 @@ export default function personRouter(services: Services): Router {
     '/',
     setupCommonData(),
     loadPrisoner(services.prisonerService),
-    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService),
+    loadRecalls(services.recallService, services.prisonService, services.manageOffencesService, services.courtService),
     loadServiceDefinitions(services.courtCasesReleaseDatesService),
     logPageView(services.auditService, Page.PERSON_HOME_PAGE),
     viewPersonHome,

--- a/server/services/manageOffencesService.ts
+++ b/server/services/manageOffencesService.ts
@@ -6,13 +6,21 @@ export default class ManageOffencesService {
     return new ManageOffencesApiClient(token).getOffencesByCodes(offenceCodes)
   }
 
+
   async getOffenceMap(offenceCodes: string[], token: string) {
-    let offenceMap = {}
-    const toSearchCodes = offenceCodes.filter(offenceCode => offenceCode)
-    if (toSearchCodes.length) {
-      const offences = await this.getOffencesByCodes(toSearchCodes, token)
-      offenceMap = Object.fromEntries(offences.map(offence => [offence.code, offence.description]))
-    }
-    return offenceMap
+  let offenceMap = {}
+  const toSearchCodes = offenceCodes.filter(offenceCode => offenceCode)
+
+  if (toSearchCodes.length) {
+    const offences = await this.getOffencesByCodes(toSearchCodes, token)
+
+    offenceMap = Object.fromEntries(offences.map(offence => [offence.code, offence.description]))
+
+  } else {
+    console.log('[ManageOffencesService] No valid offence codes provided')
   }
+
+  return offenceMap
+}
+
 }

--- a/server/services/recallService.ts
+++ b/server/services/recallService.ts
@@ -32,8 +32,6 @@ export default class RecallService {
   async getAllRecalls(nomsId: string, username: string): Promise<Recall[]> {
     const allApiRecalls = await (await this.getApiClient(username)).getAllRecalls(nomsId)
 
-    logger.info(`Fetched recalls for NOMS ID ${nomsId}:`, allApiRecalls)
-
     return allApiRecalls.map((apiRecall: ApiRecall): Recall => this.fromApiRecall(apiRecall))
   }
 


### PR DESCRIPTION
 I didn’t solve it but I can see the issue is in `loadRecalls` and its because the `sentences` inside the recalls do not contain the offenceCodes which are needed to get the offence descriptions which are the titles missing in the nunjucks
In `loadCourtCases` they do get them from the cases on line 79 and map through, of type recallableCourtCase[], which was removed from loadRecalls.
i did a few code changes but now prisonAPI has gone down and its not loading, i can put commit the branch but its pretty shit if im honest, just me fiddling about

mostly logs but useful to see where its breaking