### PR TITLE
RCLL-478: Feature toggle unexpected recall type intercept

### DIFF
--- a/helm_deploy/hmpps-record-a-recall/values.yaml
+++ b/helm_deploy/hmpps-record-a-recall/values.yaml
@@ -35,6 +35,7 @@ generic-service:
     AUDIT_SQS_REGION: "eu-west-2"
     AUDIT_SERVICE_NAME: "UNASSIGNED" # Your audit service name
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
+    UNEXPECTED_RECALL_TYPE_CHECK_ENABLED: "false"
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:

--- a/server/config.ts
+++ b/server/config.ts
@@ -214,4 +214,8 @@ export default {
       ),
     },
   },
+  featureToggles: {
+    unexpectedRecallTypeCheckEnabled:
+      get('UNEXPECTED_RECALL_TYPE_CHECK_ENABLED', 'false', requiredInProduction) === 'true',
+  },
 }

--- a/server/controllers/recall/recallTypeController.test.ts
+++ b/server/controllers/recall/recallTypeController.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest } from '@jest/globals'
+import * as formWizardHelper from '../../helpers/formWizardHelper'
+import { sessionModelFields } from '../../helpers/formWizardHelper'
+import { RecallTypes } from '../../@types/recallTypes'
+import RecallTypeController from './recallTypeController'
+import config from '../../config'
+
+describe('recallTypeController', () => {
+  let req: any
+  let res: any
+  let next: jest.Mock
+  let controller: RecallTypeController
+  const get = jest.fn() as jest.MockedFunction<(key: string) => unknown>
+
+  beforeEach(() => {
+    req = {
+      sessionModel: {
+        get,
+        set: jest.fn(),
+        unset: jest.fn(),
+      },
+      baseUrl: '/base-url',
+      form: {
+        options: {},
+      },
+    }
+
+    res = {
+      redirect: jest.fn(),
+    }
+
+    next = jest.fn()
+
+    controller = new RecallTypeController({ route: '/recall-type' })
+  })
+
+  afterEach(() => {
+    config.featureToggles.unexpectedRecallTypeCheckEnabled = false
+  })
+
+  describe('is invalid', () => {
+    beforeEach(() => {
+      // set up as invalid recall type
+      get.mockImplementation(key => {
+        if (key === formWizardHelper.sessionModelFields.RECALL_TYPE) {
+          return 'FTR_28'
+        }
+        if (key === formWizardHelper.sessionModelFields.INVALID_RECALL_TYPES) {
+          return [RecallTypes.TWENTY_EIGHT_DAY_FIXED_TERM_RECALL]
+        }
+        return null
+      })
+    })
+
+    it('sets invalid recall type flag to true if is invalid and feature toggle is on', async () => {
+      config.featureToggles.unexpectedRecallTypeCheckEnabled = true
+      await controller.successHandler(req, res, next)
+
+      expect(req.sessionModel.set).toHaveBeenCalledWith(sessionModelFields.RECALL_TYPE_MISMATCH, true)
+    })
+
+    it('sets invalid recall type flag to false if is invalid but feature toggle is false', async () => {
+      config.featureToggles.unexpectedRecallTypeCheckEnabled = false
+      await controller.successHandler(req, res, next)
+
+      expect(req.sessionModel.set).toHaveBeenCalledWith(sessionModelFields.RECALL_TYPE_MISMATCH, false)
+    })
+  })
+
+  describe('is not invalid', () => {
+    beforeEach(() => {
+      // set up as valid recall type
+      get.mockImplementation(key => {
+        if (key === formWizardHelper.sessionModelFields.RECALL_TYPE) {
+          return 'FTR_28'
+        }
+        if (key === formWizardHelper.sessionModelFields.INVALID_RECALL_TYPES) {
+          return []
+        }
+        return null
+      })
+    })
+
+    it('sets invalid recall type flag to false if is valid and feature toggle is on', async () => {
+      config.featureToggles.unexpectedRecallTypeCheckEnabled = true
+      await controller.successHandler(req, res, next)
+
+      expect(req.sessionModel.set).toHaveBeenCalledWith(sessionModelFields.RECALL_TYPE_MISMATCH, false)
+    })
+
+    it('sets invalid recall type flag to false if is valid and feature toggle is false', async () => {
+      config.featureToggles.unexpectedRecallTypeCheckEnabled = false
+      await controller.successHandler(req, res, next)
+
+      expect(req.sessionModel.set).toHaveBeenCalledWith(sessionModelFields.RECALL_TYPE_MISMATCH, false)
+    })
+  })
+})

--- a/server/controllers/recall/recallTypeController.ts
+++ b/server/controllers/recall/recallTypeController.ts
@@ -3,7 +3,8 @@ import { NextFunction, Response } from 'express'
 
 import RecallBaseController from './recallBaseController'
 import { RecallTypes } from '../../@types/recallTypes'
-import { getRecallTypeCode, sessionModelFields, getInvalidRecallTypes } from '../../helpers/formWizardHelper'
+import { getInvalidRecallTypes, getRecallTypeCode, sessionModelFields } from '../../helpers/formWizardHelper'
+import config from '../../config'
 
 export default class RecallTypeController extends RecallBaseController {
   configure(req: FormWizard.Request, res: Response, next: NextFunction) {
@@ -17,14 +18,14 @@ export default class RecallTypeController extends RecallBaseController {
   }
 
   successHandler(req: FormWizard.Request, res: Response, next: NextFunction) {
-    const selectedType = getRecallTypeCode(req)
-    const invalidRecallTypes = getInvalidRecallTypes(req)
-
-    req.sessionModel.set(
-      sessionModelFields.RECALL_TYPE_MISMATCH,
+    let recallTypeMismatch = false
+    if (config.featureToggles.unexpectedRecallTypeCheckEnabled) {
+      const selectedType = getRecallTypeCode(req)
+      const invalidRecallTypes = getInvalidRecallTypes(req)
       // @ts-expect-error Type will be correct
-      invalidRecallTypes?.map(t => t.code).includes(selectedType) || false,
-    )
+      recallTypeMismatch = invalidRecallTypes?.map(t => t.code).includes(selectedType) || false
+    }
+    req.sessionModel.set(sessionModelFields.RECALL_TYPE_MISMATCH, recallTypeMismatch)
     return super.successHandler(req, res, next)
   }
 }


### PR DESCRIPTION
This page is only triggered if we think the recall type selected is invalid but the rules have not been fleshed out fully yet so we are disabling it for now. The check is now skipped if the feature toggle is off, which it is in all environments currently.