### PR TITLE
RCLL-480: Correct formatting of court reference

### DIFF
--- a/integration_tests/e2e/update-unknown-sentence-type.cy.ts
+++ b/integration_tests/e2e/update-unknown-sentence-type.cy.ts
@@ -45,7 +45,8 @@ context('Updating single unknown sentence type - Pragmatic Approach', () => {
 
     // Verify court case selection shows unknown sentence
     Page.verifyOnPage(SelectCourtCasesPage)
-    cy.get('h2.govuk-heading-m').should('contain', 'ABRYCT')
+    cy.get('h2.govuk-heading-m').should('contain', 'CC123/2024')
+    cy.get('h2.govuk-heading-m').should('contain', 'Aberystwyth Crown Court')
 
     // Verify sentence type shows as "Required"
     cy.get('.govuk-tag--blue').should('contain', 'Required')

--- a/integration_tests/mockApis/courtRegisterApi.ts
+++ b/integration_tests/mockApis/courtRegisterApi.ts
@@ -67,6 +67,28 @@ export default {
             active: true,
             buildings: [],
           },
+          {
+            courtId: 'ABRYCT',
+            courtName: 'Aberystwyth Crown Court',
+            courtDescription: 'Aberystwyth Crown Court',
+            type: {
+              courtType: 'CRW',
+              courtName: 'Crown',
+            },
+            active: true,
+            buildings: [],
+          },
+          {
+            courtId: 'ABDRCT',
+            courtName: 'Aberdeen Crown Court',
+            courtDescription: 'Aberdeen Crown Court',
+            type: {
+              courtType: 'CRW',
+              courtName: 'Crown',
+            },
+            active: true,
+            buildings: [],
+          },
         ],
       },
     })

--- a/server/controllers/recall/selectCourtCaseController.ts
+++ b/server/controllers/recall/selectCourtCaseController.ts
@@ -108,9 +108,8 @@ export default class SelectCourtCaseController extends RecallBaseController {
     currentCase.caseReferences = originalCase.reference || 'N/A'
     currentCase.courtName =
       (originalCase as CourtCase & { courtName?: string; courtCode?: string }).courtName ||
-      (originalCase as CourtCase & { courtCode?: string }).courtCode ||
       originalCase.locationName ||
-      'N/A'
+      'Court name not available'
 
     const overallLicenceTerm = calculateOverallSentenceLength(originalCase.sentences)
     currentCase.formattedOverallSentenceLength = formatTerm(overallLicenceTerm)

--- a/server/views/pages/recall/bulk-sentence-type.njk
+++ b/server/views/pages/recall/bulk-sentence-type.njk
@@ -108,7 +108,7 @@
                                 text: "Court name"
                             },
                             value: {
-                                html: courtCase.locationName or courtCase.location
+                                html: courtCase.locationName or "Court name not available"
                             }
                         }), rows) %}
                         

--- a/server/views/pages/recall/multiple-sentence-decision.njk
+++ b/server/views/pages/recall/multiple-sentence-decision.njk
@@ -108,7 +108,7 @@
                                 text: "Court name"
                             },
                             value: {
-                                html: courtCase.locationName or courtCase.location
+                                html: courtCase.locationName or "Court name not available"
                             }
                         }), rows) %}
                         

--- a/server/views/pages/recall/select-court-case-details.njk
+++ b/server/views/pages/recall/select-court-case-details.njk
@@ -41,7 +41,7 @@
           {# Recallable Offences Section #}
           {% if currentCase.recallableSentences and currentCase.recallableSentences.length > 0 %}
             <h2 class="govuk-heading-m govuk-!-font-weight-bold govuk-!-margin-top-3 govuk-!-margin-bottom-3">
-            {% if currentCase.courtCode %}{{ currentCase.courtCode }} at {% endif %}
+            {% if currentCase.caseReferences and currentCase.caseReferences != 'N/A' %}{{ currentCase.caseReferences }} at {% endif %}
               {{ currentCase.courtName | default("N/A") }} on {{ currentCase.formattedOverallConvictionDate | default("N/A") }}
             </h2>
 

--- a/server/views/pages/recall/select-sentence-type.njk
+++ b/server/views/pages/recall/select-sentence-type.njk
@@ -112,7 +112,7 @@
                                 text: "Court name"
                             },
                             value: {
-                                text: (courtCase.locationName or courtCase.location) | safe
+                                text: (courtCase.locationName or "Court name not available") | safe
                             }
                         }), rows) %}
                         

--- a/server/views/pages/recall/update-sentence-types-summary.njk
+++ b/server/views/pages/recall/update-sentence-types-summary.njk
@@ -101,7 +101,7 @@
                         
                         {% for courtCase in unupdatedCases %}
                             <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
-                                {% if courtCase.reference %}{{ courtCase.reference }} at {% endif %}{{ courtCase.locationName or courtCase.location }} on {{ courtCase.date | formatDate }}
+                                {% if courtCase.reference %}{{ courtCase.reference }} at {% endif %}{{ courtCase.locationName or "Court name not available" }} on {{ courtCase.date | formatDate }}
                             </p>
                             
                             {% for sentence in courtCase.sentences %}
@@ -116,7 +116,7 @@
                         
                         {% for courtCase in updatedCases %}
                             <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
-                                {% if courtCase.reference %}{{ courtCase.reference }} at {% endif %}{{ courtCase.locationName or courtCase.location }} on {{ courtCase.date | formatDate }}
+                                {% if courtCase.reference %}{{ courtCase.reference }} at {% endif %}{{ courtCase.locationName or "Court name not available" }} on {{ courtCase.date | formatDate }}
                             </p>
                             
                             {% for sentence in courtCase.sentences %}


### PR DESCRIPTION
app was erroneously using courtCase.location as a fallback for location name when in fact courtCase.location is the court code